### PR TITLE
Fix CharsetStreamFilter breaking on unsupported CS

### DIFF
--- a/src/Stream/CharsetStreamFilter.php
+++ b/src/Stream/CharsetStreamFilter.php
@@ -29,7 +29,23 @@ class CharsetStreamFilter extends php_user_filter
     /**
      * @var string the character set the stream is using
      */
-    protected $charset = 'iso-8859-1';
+    protected $charset = 'ISO-8859-1';
+    
+    /**
+     * @var array an array of additional charsets supported but not documented
+     */
+    private $additionalCharsets = [
+        'CP850',
+        'GB2312'
+    ];
+    
+    /**
+     * @var array an array of translated charsets (must be upper-case)
+     */
+    private $translatedCharsets = [
+        'US-ASCII' => 'ASCII',
+        'ISO-8859-8-I' => 'ISO-8859-8',
+    ];
     
     /**
      * Filter implementation converts encoding before returning PSFS_PASS_ON.
@@ -57,12 +73,27 @@ class CharsetStreamFilter extends php_user_filter
     }
     
     /**
-     * Overridden to extract the charset from the params array.
+     * Overridden to extract the charset from the params array and check if the
+     * passed charset is supported or listed in the translation table in
+     * CharsetStreamFilter::translatedCharsets.
+     * 
+     * Unfortunately __construct doesn't seem to be called for this class, so
+     * setting up 'availableCharsets' in the constructor doesn't work out.
      */
     public function onCreate()
     {
         if (!empty($this->params['charset'])) {
-            $this->charset = $this->params['charset'];
+            $this->charset = strtoupper($this->params['charset']);
+        }
+        $availableCharsets = array_merge(
+            $this->additionalCharsets,
+            array_map('strtoupper', mb_list_encodings())
+        );
+        if (array_key_exists($this->charset, $this->translatedCharsets)) {
+            $this->charset = $this->translatedCharsets[$this->charset];
+        }
+        if (!in_array($this->charset, $availableCharsets)) {
+            $this->charset = 'pass';
         }
     }
 }


### PR DESCRIPTION
Hi @tivnet --

Would you mind giving this branch a try?  According to this post: https://bugs.python.org/issue18624 8859-8-I should work the same as 8859-8 for conversion purposes.  Unfortunately I don't have an example 8859-8-I real encoded string to test with, and couldn't find one I know to be a reliable example.

There are probably many others that will need to be added as well.  From the python bug report page which introduces a patch to their aliases file, I found http://python.ca/nas/python/sap-25/Lib/encodings/aliases.py which contains many more candidates :).  I'll have to spend some time with that and see which of those apply and are needed for MMP.

Thanks,
Zaahid