### PR TITLE
Adding WE8MSWIN1252 alias from WINDOWS-1252.

### DIFF
--- a/src/Stream/Helper/CharsetConverter.php
+++ b/src/Stream/Helper/CharsetConverter.php
@@ -51,6 +51,7 @@ class CharsetConverter
         '1252' => 'WINDOWS-1252',
         'CP1252' => 'WINDOWS-1252',
         'WINDOWS1252' => 'WINDOWS-1252',
+        'WE8MSWIN1252' => 'WINDOWS-1252',
         '1254' => 'WINDOWS-1254',
         'CP1254' => 'WINDOWS-1254',
         'WINDOWS1254' => 'WINDOWS-1254',


### PR DESCRIPTION
Hi zbateson,

First of all thank you for MailParser as we've been using for a while at it does its job really well 👍 
Yesterday we came across with the following issue when parsing an incoming email:
`Notice: iconv(): Wrong charset, conversion from WE8MSWIN1252 to UTF-8//TRANSLIT//IGNORE`
It resulted as an html content empty.
We made our way by adding the mime charset as an alias to WINDOWS-1252 and it worked.

Right now we are doing like so:

```
CharsetConverter::$mbAliases['WE8MSWIN1252'] = 'WINDOWS-1252';
$email_parser     = new MailMimeParser();
```

I've made a PR for you to consider adding this alias.

Thanks !