### PR TITLE
better check for when to close the resource

### DIFF
--- a/src/MimePart.php
+++ b/src/MimePart.php
@@ -71,7 +71,7 @@ class MimePart
      */
     public function __destruct()
     {
-        if ($this->handle !== null) {
+        if (is_resource($this->handle)) {
             fclose($this->handle);
         }
     }


### PR DESCRIPTION
Sometimes the handle could be something other than null but still fail to close. I was getting an unknown  resource which passed the null check but outputs a warning on close.