### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
     - 5.4
     - 5.5
     - 5.6
-    - 7
+    - 7.0
     - 7.1
     - 7.2
     - hhvm
@@ -15,6 +15,7 @@ php:
     - nightly
 matrix:
     allow_failures:
+        - php: hhvm
         - php: hhvm-nightly
         - php: nightly
 

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
         "zbateson/stream-decorators": "^0.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5.0",
-        "phing/phing": "~2.15.0",
-        "evert/phpdoc-md": "~0.1.1",
-        "phpdocumentor/phpdocumentor": "~2.8.0",
-        "mikey179/vfsStream": "~1.6.0"
+        "phpunit/phpunit": "^4.8",
+        "phing/phing": "^2.15.0",
+        "evert/phpdoc-md": "^0.1.1",
+        "phpdocumentor/phpdocumentor": "^2.8.0",
+        "mikey179/vfsStream": "^1.6.0"
     },
     "autoload": {
         "psr-4": {"ZBateson\\MailMimeParser\\": "src/"}
     },
     "autoload-dev": {
-        "classmap": ["tests/MailMimeParser/"]
+        "psr-4": {"ZBateson\\MailMimeParser\\": "tests/MailMimeParser"}
     }
 }

--- a/tests/MailMimeParser/Header/AddressHeaderTest.php
+++ b/tests/MailMimeParser/Header/AddressHeaderTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ZBateson\MailMimeParser\Header\Consumer\ConsumerService;
 
 /**
@@ -13,10 +13,10 @@ use ZBateson\MailMimeParser\Header\Consumer\ConsumerService;
  * @covers ZBateson\MailMimeParser\Header\AbstractHeader
  * @author Zaahid Bateson
  */
-class AddressHeaderTest extends PHPUnit_Framework_TestCase
+class AddressHeaderTest extends TestCase
 {
     protected $consumerService;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -24,14 +24,14 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         $mlpf = $this->getMock('ZBateson\MailMimeParser\Header\Part\MimeLiteralPartFactory', ['__toString'], [$charsetConverter]);
         $this->consumerService = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
     }
-    
+
     public function testEmptyHeader()
     {
         $header = new AddressHeader($this->consumerService, 'TO', '');
         $this->assertEquals('', $header->getValue());
         $this->assertNull($header->getPersonName());
     }
-    
+
     public function testSingleAddress()
     {
         $header = new AddressHeader($this->consumerService, 'From', 'koolaid@dontdrinkit.com');
@@ -39,13 +39,13 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertEmpty($header->getPersonName());
         $this->assertEquals('From', $header->getName());
     }
-    
+
     public function testAddressHeaderToString()
     {
         $header = new AddressHeader($this->consumerService, 'From', 'koolaid@dontdrinkit.com');
         $this->assertEquals('From: koolaid@dontdrinkit.com', $header);
     }
-    
+
     public function testSingleAddressWithName()
     {
         $header = new AddressHeader($this->consumerService, 'From', 'Kool Aid <koolaid@dontdrinkit.com>');
@@ -56,7 +56,7 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Kool Aid', $addresses[0]->getName());
         $this->assertEquals('koolaid@dontdrinkit.com', $addresses[0]->getValue());
     }
-    
+
     public function testSingleAddressWithQuotedName()
     {
         $header = new AddressHeader($this->consumerService, 'To', '"Jürgen Schmürgen" <schmuergen@example.com>');
@@ -65,7 +65,7 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Jürgen Schmürgen', $addresses[0]->getName());
         $this->assertEquals('schmuergen@example.com', $addresses[0]->getEmail());
     }
-    
+
     public function testComplexSingleAddress()
     {
         $header = new AddressHeader(
@@ -78,7 +78,7 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Kilgore Trout', $addresses[0]->getName());
         $this->assertEquals('kilgoretrout@ilium.ny.us', $addresses[0]->getEmail());
     }
-    
+
     public function testMultipleAddresses()
     {
         $header = new AddressHeader(
@@ -96,7 +96,7 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('The Fox', $addresses[2]->getName());
         $this->assertEquals('therose@pureawesome.com', $addresses[3]->getEmail());
     }
-    
+
     public function testAddressGroups()
     {
         $header = new AddressHeader(
@@ -108,16 +108,16 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         );
         $parts = $header->getParts();
         $this->assertCount(2, $parts);
-        
+
         $starks = $parts[0];
         $lannisters = $parts[1];
         $this->assertEquals('House Stark', $starks->getName());
         $this->assertEquals('House Lannister', $lannisters->getName());
-        
+
         $this->assertCount(3, $starks->getAddresses());
         $this->assertCount(4, $lannisters->getAddresses());
     }
-    
+
     public function testHasAddress()
     {
         $header = new AddressHeader(
@@ -135,7 +135,7 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($header->hasAddress('maxpayne@addressunknown.com'));
         $this->assertFalse($header->hasAddress('nonexistent@example.com'));
     }
-    
+
     public function testGetAddresses()
     {
         $header = new AddressHeader(
@@ -149,7 +149,7 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         $addresses = $header->getAddresses();
         $this->assertCount(8, $addresses);
         $parts = $header->getParts();
-        
+
         foreach ($parts[0]->getAddresses() as $addr) {
             $this->assertSame($addr, current($addresses));
             next($addresses);
@@ -160,7 +160,7 @@ class AddressHeaderTest extends PHPUnit_Framework_TestCase
         }
         $this->assertEquals('maxpayne@addressunknown.com', current($addresses)->getEmail());
     }
-    
+
     public function testGetGroups()
     {
         $header = new AddressHeader(

--- a/tests/MailMimeParser/Header/Consumer/AbstractConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/AbstractConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of AbstractConsumerTest
@@ -11,48 +11,48 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class AbstractConsumerTest extends PHPUnit_Framework_TestCase
+class AbstractConsumerTest extends TestCase
 {
     private $abstractConsumerStub;
-    
+
     protected function setUp()
     {
         $stub = $this->getMockBuilder('\ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer')
             ->setMethods(['combineParts', 'isEndToken', 'getPartForToken', 'getTokenSeparators', 'getSubConsumers'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        
+
         $stub->method('isEndToken')
             ->willReturn(false);
         $stub->method('getTokenSeparators')
             ->willReturn(['\s+']);
         $stub->method('getSubConsumers')
             ->willReturn([]);
-        
+
         $this->abstractConsumerStub = $stub;
     }
-    
+
     public function testSingleToken()
     {
         $value = 'teapot';
         $stub = $this->abstractConsumerStub;
-        
+
         $stub->expects($this->once())
             ->method('getPartForToken')
             ->with($value);
         $stub->method('combineParts')
             ->willReturn([$value]);
-        
+
         $ret = $stub($value);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
     }
-    
+
     public function testMultipleTokens()
     {
         $value = "Je\ \t suis\nici";
         $parts = ['Je', ' ', "\t ", 'suis', "\n", 'ici'];
-        
+
         $stub = $this->abstractConsumerStub;
 
         $stub->expects($this->exactly(6))
@@ -61,12 +61,12 @@ class AbstractConsumerTest extends PHPUnit_Framework_TestCase
             ->will($this->onConsecutiveCalls($parts[0], $parts[1], $parts[2], $parts[3], $parts[4], $parts[5]));
         $stub->method('combineParts')
             ->willReturn($parts);
-        
+
         $ret = $stub($value);
         $this->assertNotEmpty($ret);
         $this->assertCount(6, $ret);
     }
-    
+
     public function testInvokeWithEmptyValue()
     {
         $stub = $this->abstractConsumerStub;

--- a/tests/MailMimeParser/Header/Consumer/AddressBaseConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/AddressBaseConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of AddressBaseConsumerTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class AddressBaseConsumerTest extends PHPUnit_Framework_TestCase
+class AddressBaseConsumerTest extends TestCase
 {
     private $addressBaseConsumer;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -24,33 +24,33 @@ class AddressBaseConsumerTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->addressBaseConsumer = new AddressBaseConsumer($cs, $pf);
     }
-    
+
     public function testConsumeAddress()
     {
         $email = 'Max.Payne@AddressUnknown.com';
         $ret = $this->addressBaseConsumer->__invoke($email);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
-        
+
         $address = $ret[0];
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressPart', $address);
         $this->assertEquals('', $address->getName());
         $this->assertEquals($email, $address->getEmail());
     }
-    
+
     public function testConsumeAddresses()
     {
         $emails = 'Popeye@TheSailorMan.com, Olive@Oil.com, Brute <brute@isThatHisName.com>';
         $ret = $this->addressBaseConsumer->__invoke($emails);
         $this->assertNotEmpty($ret);
         $this->assertCount(3, $ret);
-        
+
         $this->assertEquals('Popeye@TheSailorMan.com', $ret[0]->getEmail());
         $this->assertEquals('Olive@Oil.com', $ret[1]->getEmail());
         $this->assertEquals('Brute', $ret[2]->getName());
         $this->assertEquals('brute@isThatHisName.com', $ret[2]->getEmail());
     }
-    
+
     public function testConsumeAddressAndGroup()
     {
         $emails = 'Tyrion Lannister <tyrion@houselannister.com>, '
@@ -59,17 +59,17 @@ class AddressBaseConsumerTest extends PHPUnit_Framework_TestCase
         $ret = $this->addressBaseConsumer->__invoke($emails);
         $this->assertNotEmpty($ret);
         $this->assertCount(3, $ret);
-        
+
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressPart', $ret[0]);
         $this->assertEquals('Tyrion Lannister', $ret[0]->getName());
         $this->assertEquals('tyrion@houselannister.com', $ret[0]->getEmail());
-        
+
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressGroupPart', $ret[1]);
         $this->assertEquals('Arya Stark', $ret[1]->getAddress(0)->getName());
         $this->assertEquals('arya@winterfell.com', $ret[1]->getAddress(0)->getEmail());
         $this->assertEquals('', $ret[1]->getAddress(1)->getName());
         $this->assertEquals('robb@winterfell.com', $ret[1]->getAddress(1)->getEmail());
-        
+
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressPart', $ret[2]);
         $this->assertEquals('jaime@houselannister.com', $ret[2]->getEmail());
     }

--- a/tests/MailMimeParser/Header/Consumer/AddressConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/AddressConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of AddressEmailConsumerTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class AddressConsumerTest extends PHPUnit_Framework_TestCase
+class AddressConsumerTest extends TestCase
 {
     private $addressConsumer;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -24,46 +24,46 @@ class AddressConsumerTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->addressConsumer = new AddressConsumer($cs, $pf);
     }
-    
+
     public function testConsumeEmail()
     {
         $email = 'Max.Payne@AddressUnknown.com';
         $ret = $this->addressConsumer->__invoke($email);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
-        
+
         $address = $ret[0];
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressPart', $address);
         $this->assertEquals('', $address->getName());
         $this->assertEquals($email, $address->getEmail());
     }
-    
+
     public function testConsumeEmailName()
     {
         $email = 'Max Payne <Max.Payne@AddressUnknown.com>';
         $ret = $this->addressConsumer->__invoke($email);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
-        
+
         $address = $ret[0];
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressPart', $address);
         $this->assertEquals('Max.Payne@AddressUnknown.com', $address->getEmail());
         $this->assertEquals('Max Payne', $address->getName());
     }
-    
+
     public function testConsumeMimeEncodedName()
     {
         $email = '=?US-ASCII?Q?Kilgore_Trout?= <Kilgore.Trout@Iliyum.ny>';
         $ret = $this->addressConsumer->__invoke($email);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
-        
+
         $address = $ret[0];
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressPart', $address);
         $this->assertEquals('Kilgore.Trout@Iliyum.ny', $address->getEmail());
         $this->assertEquals('Kilgore Trout', $address->getName());
     }
-    
+
     public function testConsumeEmailWithComments()
     {
         // can't remember any longer if this is how it should be handled
@@ -72,12 +72,12 @@ class AddressConsumerTest extends PHPUnit_Framework_TestCase
         $ret = $this->addressConsumer->__invoke($email);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
-        
+
         $address = $ret[0];
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressPart', $address);
         $this->assertEquals('Max.Payne@AddressUnknown.com', $address->getEmail());
     }
-    
+
     public function testConsumeEmailWithQuotes()
     {
         // can't remember any longer if this is how it should be handled
@@ -86,19 +86,19 @@ class AddressConsumerTest extends PHPUnit_Framework_TestCase
         $ret = $this->addressConsumer->__invoke($email);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
-        
+
         $address = $ret[0];
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressPart', $address);
         $this->assertEquals('Max(imum).Payne(comment)@AddressUnknown.com', $address->getEmail());
     }
-    
+
     public function testConsumeAddressGroup()
     {
         $email = 'Senate: Caesar@Dictator.com,Cicero@Philosophy.com, Marc Antony <MarcAntony@imawesome.it>';
         $ret = $this->addressConsumer->__invoke($email);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
-        
+
         $addressGroup = $ret[0];
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressGroupPart', $addressGroup);
         $this->assertEquals('Senate', $addressGroup->getName());

--- a/tests/MailMimeParser/Header/Consumer/AddressGroupConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/AddressGroupConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of AddressGroupConsumerTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class AddressGroupConsumerTest extends PHPUnit_Framework_TestCase
+class AddressGroupConsumerTest extends TestCase
 {
     private $addressGroupConsumer;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -24,7 +24,7 @@ class AddressGroupConsumerTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->addressGroupConsumer = new AddressGroupConsumer($cs, $pf);
     }
-    
+
     public function testConsumeGroup()
     {
         $group = 'Wilfred, Emma';
@@ -35,7 +35,7 @@ class AddressGroupConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Wilfred', $ret[0]->getAddress(0)->getEmail());
         $this->assertEquals('Emma', $ret[0]->getAddress(1)->getEmail());
     }
-    
+
     public function testConsumeGroupWithinGroup()
     {
         $group = 'Wilfred, Bubba: One, Two';

--- a/tests/MailMimeParser/Header/Consumer/CommentConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/CommentConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of CommentConsumerTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class CommentConsumerTest extends PHPUnit_Framework_TestCase
+class CommentConsumerTest extends TestCase
 {
     private $commentConsumer;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -24,7 +24,7 @@ class CommentConsumerTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->commentConsumer = new CommentConsumer($cs, $pf);
     }
-    
+
     protected function assertCommentConsumed($expected, $value)
     {
         $ret = $this->commentConsumer->__invoke($value);
@@ -34,25 +34,25 @@ class CommentConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $ret[0]->getValue());
         $this->assertEquals($expected, $ret[0]->getComment());
     }
-    
+
     public function testConsumeTokens()
     {
         $comment = 'Some silly comment made about my moustache';
         $this->assertCommentConsumed($comment, $comment);
     }
-    
+
     public function testNestedComments()
     {
         $comment = 'A very silly comment (made about my (very awesome) moustache no less)';
         $this->assertCommentConsumed($comment, $comment);
     }
-    
+
     public function testCommentWithQuotedLiteral()
     {
         $comment = 'A ("very ) wrong") comment was made (about my moustache obviously)';
         $this->assertCommentConsumed($comment, $comment);
     }
-    
+
     public function testMimeEncodedComment()
     {
         $this->assertCommentConsumed(

--- a/tests/MailMimeParser/Header/Consumer/ConsumerServiceTest.php
+++ b/tests/MailMimeParser/Header/Consumer/ConsumerServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of ConsumerServiceTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class ConsumerServiceTest extends PHPUnit_Framework_TestCase
+class ConsumerServiceTest extends TestCase
 {
     private $consumerService;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -23,56 +23,56 @@ class ConsumerServiceTest extends PHPUnit_Framework_TestCase
         $mlpf = $this->getMock('ZBateson\MailMimeParser\Header\Part\MimeLiteralPartFactory', ['__toString'], [$charsetConverter]);
         $this->consumerService = new ConsumerService($pf, $mlpf);
     }
-    
+
     public function testGetAddressBaseConsumer()
     {
         $consumer = $this->consumerService->getAddressBaseConsumer();
         $this->assertNotNull($consumer);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Consumer\AddressBaseConsumer', $consumer);
     }
-    
+
     public function testGetAddressConsumer()
     {
         $consumer = $this->consumerService->getAddressConsumer();
         $this->assertNotNull($consumer);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Consumer\AddressConsumer', $consumer);
     }
-    
+
     public function testGetAddressGroupConsumer()
     {
         $consumer = $this->consumerService->getAddressGroupConsumer();
         $this->assertNotNull($consumer);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Consumer\AddressGroupConsumer', $consumer);
     }
-    
+
     public function testGetCommentConsumer()
     {
         $consumer = $this->consumerService->getCommentConsumer();
         $this->assertNotNull($consumer);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Consumer\CommentConsumer', $consumer);
     }
-    
+
     public function testGetGenericConsumer()
     {
         $consumer = $this->consumerService->getGenericConsumer();
         $this->assertNotNull($consumer);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Consumer\GenericConsumer', $consumer);
     }
-    
+
     public function testGetQuotedStringConsumer()
     {
         $consumer = $this->consumerService->getQuotedStringConsumer();
         $this->assertNotNull($consumer);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Consumer\QuotedStringConsumer', $consumer);
     }
-    
+
     public function testGetDateConsumer()
     {
         $consumer = $this->consumerService->getDateConsumer();
         $this->assertNotNull($consumer);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Consumer\DateConsumer', $consumer);
     }
-    
+
     public function testGetParameterConsumer()
     {
         $consumer = $this->consumerService->getParameterConsumer();

--- a/tests/MailMimeParser/Header/Consumer/DateConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/DateConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use DateTime;
 
 /**
@@ -13,10 +13,10 @@ use DateTime;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class DateConsumerTest extends PHPUnit_Framework_TestCase
+class DateConsumerTest extends TestCase
 {
     private $dateConsumer;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -25,7 +25,7 @@ class DateConsumerTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->dateConsumer = new DateConsumer($cs, $pf);
     }
-    
+
     public function testConsumeDates()
     {
         $date = 'Wed, 17 May 2000 19:08:29 -0400';
@@ -36,7 +36,7 @@ class DateConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($date, $ret[0]->getValue());
         $this->assertEquals($date, $ret[0]->getDateTime()->format(DateTime::RFC2822));
     }
-    
+
     public function testConsumeDateWithComment()
     {
         $dateTest = 'Wed, 17 May 2000 19:08:29 -0400 (some comment)';

--- a/tests/MailMimeParser/Header/Consumer/GenericConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/GenericConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of GenericConsumerTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class GenericConsumerTest extends PHPUnit_Framework_TestCase
+class GenericConsumerTest extends TestCase
 {
     private $genericConsumer;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -24,21 +24,21 @@ class GenericConsumerTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->genericConsumer = new GenericConsumer($cs, $mlpf);
     }
-    
+
     public function testConsumeTokens()
     {
         $value = "Je\ \t suis\nici";
-        
+
         $ret = $this->genericConsumer->__invoke($value);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
         $this->assertEquals('Je  suis ici', $ret[0]);
     }
-    
+
     public function testFilterSpacesBetweenMimeParts()
     {
         $value = "=?US-ASCII?Q?Je?=    =?US-ASCII?Q?suis?=\n=?US-ASCII?Q?ici?=";
-        
+
         $ret = $this->genericConsumer->__invoke($value);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);

--- a/tests/MailMimeParser/Header/Consumer/ParameterConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/ParameterConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of ParameterConsumerTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class ParameterConsumerTest extends PHPUnit_Framework_TestCase
+class ParameterConsumerTest extends TestCase
 {
     private $parameterConsumer;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -24,7 +24,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->parameterConsumer = new ParameterConsumer($cs, $pf);
     }
-    
+
     public function testConsumeTokens()
     {
         $ret = $this->parameterConsumer->__invoke('text/html; charset=utf8');
@@ -36,7 +36,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('charset', $ret[1]->getName());
         $this->assertEquals('utf8', $ret[1]->getValue());
     }
-    
+
     public function testEscapedSeparators()
     {
         $ret = $this->parameterConsumer->__invoke('test\;with\;special\=chars; and\=more=blah');
@@ -46,7 +46,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('and=more', $ret[1]->getName());
         $this->assertEquals('blah', $ret[1]->getValue());
     }
-    
+
     public function testWithSubConsumers()
     {
         $ret = $this->parameterConsumer->__invoke('hotdogs; weiner="all-beef";toppings=sriracha (boo-yah!)');
@@ -58,7 +58,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('toppings', $ret[2]->getName());
         $this->assertEquals('sriracha', $ret[2]->getValue());
     }
-    
+
     public function testSimpleSplitHeader()
     {
         $ret = $this->parameterConsumer->__invoke('hotdogs; condiments*0="mustar";'
@@ -70,7 +70,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('mustard, ketchup and mayo', $ret[1]->getValue());
         $this->assertNull($ret[1]->getLanguage());
     }
-    
+
     public function testSplitHeaderInFunnyOrder()
     {
         $ret = $this->parameterConsumer->__invoke('hotdogs; condiments*2=" and mayo";'
@@ -82,7 +82,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('mustard, ketchup and mayo', $ret[1]->getValue());
         $this->assertNull($ret[1]->getLanguage());
     }
-    
+
     public function testSplitHeaderWithEmptyEncodingAndLanguage()
     {
         $ret = $this->parameterConsumer->__invoke('hotdogs; condiments*=\'\''
@@ -94,7 +94,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('mustard, ketchup and mayo', $ret[1]->getValue());
         $this->assertNull($ret[1]->getLanguage());
     }
-    
+
     public function testSplitHeaderWithEncodingAndLanguage()
     {
         $ret = $this->parameterConsumer->__invoke('hotdogs; condiments*=us-ascii\'en-US\''
@@ -106,7 +106,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('mustard, ketchup and mayo', $ret[1]->getValue());
         $this->assertEquals('en-US', $ret[1]->getLanguage());
     }
-    
+
     public function testSplitHeaderWithMultiByteEncodedPart()
     {
         $ret = $this->parameterConsumer->__invoke('hotdogs; condiments*=utf-8\'\''
@@ -118,7 +118,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('mustardized–ketchup', $ret[1]->getValue());
         $this->assertNull($ret[1]->getLanguage());
     }
-    
+
     public function testSplitHeaderWithMultiByteEncodedPartAndLanguage()
     {
         $str = 'هلا هلا شخبار بعد؟ شلون تبرمج؟';
@@ -126,7 +126,7 @@ class ParameterConsumerTest extends PHPUnit_Framework_TestCase
         $halfPos = floor((strlen($encoded) / 3) / 2) * 3;
         $part1 = substr($encoded, 0, $halfPos);
         $part2 = substr($encoded, $halfPos);
-        
+
         $ret = $this->parameterConsumer->__invoke('hotdogs; condiments*0*=utf-8\'abv-BH\''. $part1
             . '; condiments*1*=' . $part2);
         $this->assertNotEmpty($ret);

--- a/tests/MailMimeParser/Header/Consumer/QuotedStringConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/QuotedStringConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of QuotedStringConsumerTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class QuotedStringConsumerTest extends PHPUnit_Framework_TestCase
+class QuotedStringConsumerTest extends TestCase
 {
     private $quotedStringConsumer;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -24,11 +24,11 @@ class QuotedStringConsumerTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->quotedStringConsumer = new QuotedStringConsumer($cs, $pf);
     }
-    
+
     public function testConsumeTokens()
     {
         $value = 'Will end at " quote';
-        
+
         $ret = $this->quotedStringConsumer->__invoke($value);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);

--- a/tests/MailMimeParser/Header/Consumer/SubjectConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/SubjectConsumerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Consumer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of SubjectConsumerTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer
  * @author Zaahid Bateson
  */
-class SubjectConsumerTest extends PHPUnit_Framework_TestCase
+class SubjectConsumerTest extends TestCase
 {
     private $subjectConsumer;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -24,21 +24,21 @@ class SubjectConsumerTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->subjectConsumer = new SubjectConsumer($cs, $mlpf);
     }
-    
+
     public function testConsumeTokens()
     {
         $value = "Je\ \t suis\nici";
-        
+
         $ret = $this->subjectConsumer->__invoke($value);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);
         $this->assertEquals('Je\ suis ici', $ret[0]);
     }
-    
+
     public function testFilterSpacesBetweenMimeParts()
     {
         $value = "=?US-ASCII?Q?Je?=    =?US-ASCII?Q?suis?=\n=?US-ASCII?Q?ici?=";
-        
+
         $ret = $this->subjectConsumer->__invoke($value);
         $this->assertNotEmpty($ret);
         $this->assertCount(1, $ret);

--- a/tests/MailMimeParser/Header/DateHeaderTest.php
+++ b/tests/MailMimeParser/Header/DateHeaderTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of DateHeaderTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\AbstractHeader
  * @author Zaahid Bateson
  */
-class DateHeaderTest extends PHPUnit_Framework_TestCase
+class DateHeaderTest extends TestCase
 {
     protected $consumerService;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -23,7 +23,7 @@ class DateHeaderTest extends PHPUnit_Framework_TestCase
         $mlpf = $this->getMock('ZBateson\MailMimeParser\Header\Part\MimeLiteralPartFactory', ['__toString'], [$charsetConverter]);
         $this->consumerService = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
     }
-    
+
     public function testSimpleDate()
     {
         $header = new DateHeader($this->consumerService, 'Date', 'Wed, 17 May 2000 19:08:29 -0400');
@@ -32,20 +32,20 @@ class DateHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($dt);
         $this->assertEquals('Wed, 17 May 2000 19:08:29 -0400', $dt->format(\DateTime::RFC2822));
     }
-    
+
     public function testInvalidDate()
     {
         $header = new DateHeader($this->consumerService, 'DATE', 'This is not a date');
         $this->assertNull($header->getDateTime());
         $this->assertEquals('This is not a date', $header->getValue());
     }
-    
+
     public function testDateWithEmptyPart()
     {
         $header = new DateHeader($this->consumerService, 'DATE', '');
         $this->assertNull($header->getDateTime());
     }
-    
+
     public function testDateHeaderToString()
     {
         $header = new DateHeader($this->consumerService, 'Date', 'Wed, 17 May 2000 19:08:29 -0400');

--- a/tests/MailMimeParser/Header/GenericHeaderTest.php
+++ b/tests/MailMimeParser/Header/GenericHeaderTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of GenericHeaderTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\AbstractHeader
  * @author Zaahid Bateson
  */
-class GenericHeaderTest extends PHPUnit_Framework_TestCase
+class GenericHeaderTest extends TestCase
 {
     protected $consumerService;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -23,7 +23,7 @@ class GenericHeaderTest extends PHPUnit_Framework_TestCase
         $mlpf = $this->getMock('ZBateson\MailMimeParser\Header\Part\MimeLiteralPartFactory', ['__toString'], [$charsetConverter]);
         $this->consumerService = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
     }
-    
+
     public function testParsing()
     {
         $header = new GenericHeader($this->consumerService, 'Hunted-By', 'Hunter S. Thompson');
@@ -32,7 +32,7 @@ class GenericHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $header->getParts());
         $this->assertEquals('Hunted-By', $header->getName());
     }
-    
+
     public function testMultilineMimeParts()
     {
         $header = new GenericHeader($this->consumerService, 'Hunted-By', '=?US-ASCII?Q?Hunt?=
@@ -40,9 +40,9 @@ class GenericHeaderTest extends PHPUnit_Framework_TestCase
              =?US-ASCII?Q?Thompson?=');
         $this->assertEquals('Hunter S. Thompson', $header->getValue());
     }
-    
+
     /**
-     * 
+     *
      * @covers ZBateson\MailMimeParser\Header\Consumer\QuotedStringConsumer::isStartToken
      * @covers ZBateson\MailMimeParser\Header\Consumer\QuotedStringConsumer::isEndToken
      */
@@ -55,7 +55,7 @@ class GenericHeaderTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals('Dwayne "The Rock" Jackson', $header->getValue());
     }
-    
+
     public function testCommentBetweenParts()
     {
         $header = new GenericHeader(
@@ -65,7 +65,7 @@ class GenericHeaderTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals('Dwayne Jackson', $header->getValue());
     }
-    
+
     public function testGenericHeaderToString()
     {
         $header = new GenericHeader($this->consumerService, 'Hunted-By', 'Hunter S. Thompson');

--- a/tests/MailMimeParser/Header/HeaderContainerTest.php
+++ b/tests/MailMimeParser/Header/HeaderContainerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of HeaderContainerTest
@@ -11,17 +11,17 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\HeaderContainer
  * @author Zaahid Bateson
  */
-class HeaderContainerTest extends PHPUnit_Framework_TestCase
+class HeaderContainerTest extends TestCase
 {
     protected $mockHeaderFactory;
-    
+
     protected function setUp()
     {
         $this->mockHeaderFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Header\HeaderFactory')
             ->disableOriginalConstructor()
             ->getMock();
     }
-    
+
     public function testAddExistsGet()
     {
         $ob = new HeaderContainer($this->mockHeaderFactory);
@@ -84,7 +84,7 @@ class HeaderContainerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('repeated-first', $ob->get('repeated', 0));
         $this->assertEquals('repeated-second', $ob->get('repeated', 1));
         $this->assertEquals('repeated-third', $ob->get('repeated', 2));
-        
+
         $instanceHeaders = [
             'repeated-first', 'repeated-second', 'repeated-third'
         ];
@@ -250,7 +250,7 @@ class HeaderContainerTest extends PHPUnit_Framework_TestCase
 
         $this->assertNull($ob->get('first', 1));
         $this->assertEquals('second-first-value', $ob->get('first'));
-        
+
         $ob->remove('second', 1);
         $this->assertTrue($ob->exists('second'));
         $this->assertTrue($ob->exists('second', 1));

--- a/tests/MailMimeParser/Header/HeaderFactoryTest.php
+++ b/tests/MailMimeParser/Header/HeaderFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of HeaderFactoryTest
@@ -11,10 +11,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\HeaderFactory
  * @author Zaahid Bateson
  */
-class HeaderFactoryTest extends PHPUnit_Framework_TestCase
+class HeaderFactoryTest extends TestCase
 {
     protected $headerFactory;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -23,7 +23,7 @@ class HeaderFactoryTest extends PHPUnit_Framework_TestCase
         $cs = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
         $this->headerFactory = new HeaderFactory($cs, $pf);
     }
-    
+
     public function testAddressHeaderInstance()
     {
         $aValid = ['BCC', 'to', 'FrOM'];
@@ -39,7 +39,7 @@ class HeaderFactoryTest extends PHPUnit_Framework_TestCase
             $this->assertNotEquals('ZBateson\MailMimeParser\Header\AddressHeader', get_class($header));
         }
     }
-    
+
     public function testDateHeaderInstance()
     {
         $aValid = ['Date', 'ExpIRY-Date', 'EXPIRES'];
@@ -55,7 +55,7 @@ class HeaderFactoryTest extends PHPUnit_Framework_TestCase
             $this->assertNotEquals('ZBateson\MailMimeParser\Header\DateHeader', get_class($header));
         }
     }
-    
+
     public function testGenericHeaderInstance()
     {
         $aValid = ['Content-Id', 'content-ID', 'IN-REPLY-TO'];
@@ -87,7 +87,7 @@ class HeaderFactoryTest extends PHPUnit_Framework_TestCase
             $this->assertNotEquals('ZBateson\MailMimeParser\Header\SubjectHeader', get_class($header));
         }
     }
-    
+
     public function testParameterHeaderInstance()
     {
         $aValid = ['Content-Type', 'CONTENT-Disposition'];

--- a/tests/MailMimeParser/Header/ParameterHeaderTest.php
+++ b/tests/MailMimeParser/Header/ParameterHeaderTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of ParametersHeaderTest
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\AbstractHeader
  * @author Zaahid Bateson
  */
-class ParameterHeaderTest extends PHPUnit_Framework_TestCase
+class ParameterHeaderTest extends TestCase
 {
     protected $consumerService;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -23,20 +23,20 @@ class ParameterHeaderTest extends PHPUnit_Framework_TestCase
         $mlpf = $this->getMock('ZBateson\MailMimeParser\Header\Part\MimeLiteralPartFactory', ['__toString'], [$charsetConverter]);
         $this->consumerService = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
     }
-    
+
     public function testParsingContentTypeWithoutParameters()
     {
         $header = new ParameterHeader($this->consumerService, 'Content-Type', 'text/html');
         $this->assertEquals('text/html', $header->getValue());
     }
-    
+
     public function testParsingContentType()
     {
         $header = new ParameterHeader($this->consumerService, 'Content-Type', 'text/html; CHARSET="utf-8"');
         $this->assertEquals('text/html', $header->getValue());
         $this->assertEquals('utf-8', $header->getValueFor('charset'));
     }
-    
+
     public function testParsingMultipleParts()
     {
         $header = new ParameterHeader($this->consumerService, 'Content-Type', 'TEXT/html; CHARSET=utf-8; Boundary="blooh";answer-to-everything=42');
@@ -45,14 +45,14 @@ class ParameterHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('blooh', $header->getValueFor('boundary'));
         $this->assertEquals('42', $header->getValueFor('answer-to-everything'));
     }
-    
+
     public function testDefaultParameterValue()
     {
         $header = new ParameterHeader($this->consumerService, 'Content-Type', 'text/html; CHARSET="utf-8"');
         $this->assertEquals(null, $header->getValueFor('boundary'));
         $this->assertEquals('default', $header->getValueFor('test', 'default'));
     }
-    
+
     public function testParameterHeaderToString()
     {
         $header = new ParameterHeader($this->consumerService, 'Content-Type', 'text/html; CHARSET="utf-8"');

--- a/tests/MailMimeParser/Header/Part/AddressGroupPartTest.php
+++ b/tests/MailMimeParser/Header/Part/AddressGroupPartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of AddressGroupTest
@@ -12,7 +12,7 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class AddressGroupPartTest extends PHPUnit_Framework_TestCase
+class AddressGroupPartTest extends TestCase
 {
     public function testNameGroup()
     {

--- a/tests/MailMimeParser/Header/Part/AddressPartTest.php
+++ b/tests/MailMimeParser/Header/Part/AddressPartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of AddressPartTest
@@ -12,15 +12,15 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class AddressPartTest extends PHPUnit_Framework_TestCase
+class AddressPartTest extends TestCase
 {
     private $charsetConverter;
-    
+
     public function setUp()
     {
         $this->charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
     }
-    
+
     public function testNameEmail()
     {
         $name = 'Julius Caeser';
@@ -29,7 +29,7 @@ class AddressPartTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($name, $part->getName());
         $this->assertEquals($email, $part->getEmail());
     }
-    
+
     public function testEmailSpacesStripped()
     {
         $email = "gaius julius\t\n caesar@altavista.com";

--- a/tests/MailMimeParser/Header/Part/CommentPartTest.php
+++ b/tests/MailMimeParser/Header/Part/CommentPartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of CommentTest
@@ -12,15 +12,15 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class CommentPartTest extends PHPUnit_Framework_TestCase
+class CommentPartTest extends TestCase
 {
     private $charsetConverter;
-    
+
     public function setUp()
     {
         $this->charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
     }
-    
+
     public function testBasicComment()
     {
         $comment = 'Some silly comment made about my moustache';
@@ -28,7 +28,7 @@ class CommentPartTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $part->getValue());
         $this->assertEquals($comment, $part->getComment());
     }
-    
+
     public function testMimeEncoding()
     {
         $this->charsetConverter->expects($this->once())

--- a/tests/MailMimeParser/Header/Part/DatePartTest.php
+++ b/tests/MailMimeParser/Header/Part/DatePartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use DateTime;
 
 /**
@@ -13,15 +13,15 @@ use DateTime;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class DatePartTest extends PHPUnit_Framework_TestCase
+class DatePartTest extends TestCase
 {
     private $charsetConverter;
-    
+
     public function setUp()
     {
         $this->charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
     }
-    
+
     public function testDateString()
     {
         $value = 'Wed, 17 May 2000 19:08:29 -0400';
@@ -31,7 +31,7 @@ class DatePartTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($date);
         $this->assertEquals($value, $date->format(DateTime::RFC2822));
     }
-    
+
     public function testInvalidDate()
     {
         $value = 'Invalid Date';

--- a/tests/MailMimeParser/Header/Part/HeaderPartFactoryTest.php
+++ b/tests/MailMimeParser/Header/Part/HeaderPartFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of HeaderPartFactoryTest
@@ -11,79 +11,79 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPartFactory
  * @author Zaahid Bateson
  */
-class HeaderPartFactoryTest extends PHPUnit_Framework_TestCase
+class HeaderPartFactoryTest extends TestCase
 {
     private $headerPartFactory;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
         $this->headerPartFactory = new HeaderPartFactory($charsetConverter);
     }
-    
+
     public function testNewInstance()
     {
         $token = $this->headerPartFactory->newInstance('Test');
         $this->assertNotNull($token);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\Token', $token);
     }
-    
+
     public function testNewToken()
     {
         $token = $this->headerPartFactory->newToken('Test');
         $this->assertNotNull($token);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\Token', $token);
     }
-    
+
     public function testNewSplitParameterToken()
     {
         $token = $this->headerPartFactory->newSplitParameterToken('Test');
         $this->assertNotNull($token);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\SplitParameterToken', $token);
     }
-    
+
     public function testNewLiteralPart()
     {
         $part = $this->headerPartFactory->newLiteralPart('Test');
         $this->assertNotNull($part);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\LiteralPart', $part);
     }
-    
+
     public function testNewMimeLiteralPart()
     {
         $part = $this->headerPartFactory->newMimeLiteralPart('Test');
         $this->assertNotNull($part);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\MimeLiteralPart', $part);
     }
-    
+
     public function testNewCommentPart()
     {
         $part = $this->headerPartFactory->newCommentPart('Test');
         $this->assertNotNull($part);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\CommentPart', $part);
     }
-    
+
     public function testNewAddressPart()
     {
         $part = $this->headerPartFactory->newAddressPart('Test', 'Test');
         $this->assertNotNull($part);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressPart', $part);
     }
-    
+
     public function testNewAddressGroupPart()
     {
         $part = $this->headerPartFactory->newAddressGroupPart(['Test']);
         $this->assertNotNull($part);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\AddressGroupPart', $part);
     }
-    
+
     public function testNewDatePart()
     {
         $part = $this->headerPartFactory->newDatePart('Test');
         $this->assertNotNull($part);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Header\Part\DatePart', $part);
     }
-    
+
     public function testNewParameterPart()
     {
         $part = $this->headerPartFactory->newParameterPart('Test', 'Test');

--- a/tests/MailMimeParser/Header/Part/HeaderPartTest.php
+++ b/tests/MailMimeParser/Header/Part/HeaderPartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of HeaderPartTest
@@ -11,10 +11,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class HeaderPartTest extends PHPUnit_Framework_TestCase
+class HeaderPartTest extends TestCase
 {
     private $abstractHeaderPartStub;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
@@ -23,7 +23,7 @@ class HeaderPartTest extends PHPUnit_Framework_TestCase
             ->getMockForAbstractClass();
         $this->abstractHeaderPartStub = $stub;
     }
-    
+
     public function testIgnoreSpaces()
     {
         $this->assertFalse($this->abstractHeaderPartStub->ignoreSpacesBefore());

--- a/tests/MailMimeParser/Header/Part/LiteralPartTest.php
+++ b/tests/MailMimeParser/Header/Part/LiteralPartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of LiteralTest
@@ -12,16 +12,16 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class LiteralPartTest extends PHPUnit_Framework_TestCase
+class LiteralPartTest extends TestCase
 {
     public function testInstance()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
-        
+
         $part = new LiteralPart($charsetConverter, '"');
         $this->assertNotNull($part);
         $this->assertEquals('"', $part->getValue());
-        
+
         $part = new LiteralPart($charsetConverter, '=?US-ASCII?Q?Kilgore_Trout?=');
         $this->assertEquals('=?US-ASCII?Q?Kilgore_Trout?=', $part->getValue());
     }

--- a/tests/MailMimeParser/Header/Part/MimeLiteralPartFactoryTest.php
+++ b/tests/MailMimeParser/Header/Part/MimeLiteralPartFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of MimeLiteralPartFactoryTest
@@ -11,16 +11,16 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\MimeLiteralPartFactory
  * @author Zaahid Bateson
  */
-class MimeLiteralPartFactoryTest extends PHPUnit_Framework_TestCase
+class MimeLiteralPartFactoryTest extends TestCase
 {
     protected $headerPartFactory;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
         $this->headerPartFactory = new MimeLiteralPartFactory($charsetConverter);
     }
-    
+
     public function testNewInstance()
     {
         $token = $this->headerPartFactory->newInstance('Test');

--- a/tests/MailMimeParser/Header/Part/MimeLiteralPartTest.php
+++ b/tests/MailMimeParser/Header/Part/MimeLiteralPartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of MimeLiteralTest
@@ -12,29 +12,29 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class MimeLiteralPartTest extends PHPUnit_Framework_TestCase
+class MimeLiteralPartTest extends TestCase
 {
     private $charsetConverter;
-    
+
     public function setUp()
     {
         $this->charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
     }
-    
+
     protected function assertDecoded($expected, $encodedActual)
     {
         $part = new MimeLiteralPart($this->charsetConverter, $encodedActual);
         $this->assertEquals($expected, $part->getValue());
         return $part;
     }
-    
+
     public function testBasicValue()
     {
         $this->charsetConverter->expects($this->never())
             ->method('convert');
         $this->assertDecoded('Step', 'Step');
     }
-    
+
     public function testNullLanguage()
     {
         $this->charsetConverter->expects($this->never())
@@ -44,7 +44,7 @@ class MimeLiteralPartTest extends PHPUnit_Framework_TestCase
             [ 'lang' => null, 'value' => 'Step' ]
         ], $part->getLanguageArray());
     }
-    
+
     public function testMimeEncoding()
     {
         $this->charsetConverter->expects($this->once())
@@ -53,7 +53,7 @@ class MimeLiteralPartTest extends PHPUnit_Framework_TestCase
             ->willReturn('Kilgore Trout');
         $this->assertDecoded('Kilgore Trout', '=?US-ASCII?Q?Kilgore_Trout?=');
     }
-    
+
     public function testMimeEncodingNullLanguage()
     {
         $this->charsetConverter->expects($this->once())
@@ -65,12 +65,12 @@ class MimeLiteralPartTest extends PHPUnit_Framework_TestCase
             [ 'lang' => null, 'value' => 'Kilgore Trout' ]
         ], $part->getLanguageArray());
     }
-    
+
     public function testEncodingTwoParts()
     {
         $kilgore = '=?US-ASCII?Q?Kilgore_Trout?=';
         $snow = '=?US-ASCII?Q?Jon_Snow?=';
-        
+
         $this->charsetConverter->expects($this->exactly(7))
             ->method('convert')
             ->withConsecutive(
@@ -91,7 +91,7 @@ class MimeLiteralPartTest extends PHPUnit_Framework_TestCase
                 'Jon Snow',
                 'Jon Snow'
             );
-        
+
         $this->assertDecoded(
             ' Kilgore TroutJon Snow ',
             " $kilgore   $snow "
@@ -113,13 +113,13 @@ class MimeLiteralPartTest extends PHPUnit_Framework_TestCase
             "Kilgore{$snow}Trout"
         );
     }
-    
+
     public function testNonAscii()
     {
         $this->charsetConverter = $this->getMockBuilder('ZBateson\StreamDecorators\Util\CharsetConverter')
             ->setMethods(['__toString'])
             ->getMock();
-        
+
         $this->assertDecoded(
             'κόσμε fløde',
             '=?UTF-8?B?zrrhvbnPg868zrUgZmzDuGRl?='
@@ -163,34 +163,34 @@ class MimeLiteralPartTest extends PHPUnit_Framework_TestCase
         $this->assertDecoded('外為ｵﾝﾗｲﾝﾃﾞﾓ(25)(デモ)決済約定のお知らせ', '=?iso-2022-jp?Q?=1B$B300Y=1B(I5]W2]C^S=1B(B(25?=
             =?iso-2022-jp?Q?)(=1B$B%G%b=1B(B)=1B$B7h:QLsDj$N$*CN$i$;=1B(B?=');
     }
-    
+
     public function testIgnoreSpacesBefore()
     {
         $part = new MimeLiteralPart($this->charsetConverter, '=?US-ASCII?Q?Kilgore_Trout?=Blah');
         $this->assertTrue($part->ignoreSpacesBefore(), 'ignore spaces before');
         $this->assertFalse($part->ignoreSpacesAfter(), 'ignore spaces after');
     }
-    
+
     public function testIgnoreSpacesAfter()
     {
         $part = new MimeLiteralPart($this->charsetConverter, 'Blah=?US-ASCII?Q?Kilgore_Trout?=');
         $this->assertFalse($part->ignoreSpacesBefore(), 'ignore spaces before');
         $this->assertTrue($part->ignoreSpacesAfter(), 'ignore spaces after');
     }
-    
+
     public function testIgnoreSpacesBeforeAndAfter()
     {
         $part = new MimeLiteralPart($this->charsetConverter, '=?US-ASCII?Q?Kilgore_Trout?=');
         $this->assertTrue($part->ignoreSpacesBefore(), 'ignore spaces before');
         $this->assertTrue($part->ignoreSpacesAfter(), 'ignore spaces after');
     }
-    
+
     public function testLanguageParts()
     {
         $this->charsetConverter = $this->getMockBuilder('ZBateson\StreamDecorators\Util\CharsetConverter')
             ->setMethods(['__toString'])
             ->getMock();
-        
+
         $part = $this->assertDecoded(
             'Hello and bonjour mi amici. Welcome!',
             'Hello and =?UTF-8*fr-be?Q?bonjour_?= =?UTF-8*it?Q?mi amici?=. Welcome!'

--- a/tests/MailMimeParser/Header/Part/ParameterPartTest.php
+++ b/tests/MailMimeParser/Header/Part/ParameterPartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of ParameterTest
@@ -12,22 +12,22 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class ParameterPartTest extends PHPUnit_Framework_TestCase
+class ParameterPartTest extends TestCase
 {
     private $charsetConverter;
-    
+
     public function setUp()
     {
         $this->charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
     }
-    
+
     public function testBasicNameValuePair()
     {
         $part = new ParameterPart($this->charsetConverter, 'Name', 'Value');
         $this->assertEquals('Name', $part->getName());
         $this->assertEquals('Value', $part->getValue());
     }
-    
+
     public function testMimeValue()
     {
         $this->charsetConverter->expects($this->once())
@@ -38,7 +38,7 @@ class ParameterPartTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('name', $part->getName());
         $this->assertEquals('Kilgore Trout', $part->getValue());
     }
-    
+
     public function testMimeName()
     {
         $this->charsetConverter->expects($this->once())
@@ -49,7 +49,7 @@ class ParameterPartTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('name', $part->getName());
         $this->assertEquals('Kilgore', $part->getValue());
     }
-    
+
     public function testNameValueNotDecodedWithLanguage()
     {
         $this->charsetConverter->expects($this->never())
@@ -58,7 +58,7 @@ class ParameterPartTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('=?US-ASCII?Q?name?=', $part->getName());
         $this->assertEquals('=?US-ASCII?Q?Kilgore_Trout?=', $part->getValue());
     }
-    
+
     public function testGetLanguage()
     {
         $this->charsetConverter->expects($this->never())

--- a/tests/MailMimeParser/Header/Part/SplitParameterTokenTest.php
+++ b/tests/MailMimeParser/Header/Part/SplitParameterTokenTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of ParameterTest
@@ -12,43 +12,43 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
+class SplitParameterTokenTest extends TestCase
 {
     private $charsetConverter;
-    
+
     public function setUp()
     {
         $this->charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
     }
-    
+
     public function testGetNameAndNullLanguage()
     {
         $part = new SplitParameterToken($this->charsetConverter, '  Drogo  ');
         $this->assertEquals('Drogo', $part->getName());
         $this->assertNull($part->getLanguage());
     }
-    
+
     public function testLanguageIsSetBeforeGetValue()
     {
         $part = new SplitParameterToken($this->charsetConverter, '  Drogo  ');
         $part->addPart('unknown\'Dothraki\'blah', true, '');
         $this->assertEquals('Dothraki', $part->getLanguage());
     }
-    
+
     public function testLanguageIsNullForEmptyEncodedLanguage()
     {
         $part = new SplitParameterToken($this->charsetConverter, 'name');
         $part->addPart('unknown\'\'Khal%20Drogo,%20', true, 0);
         $this->assertNull($part->getLanguage());
     }
-    
+
     public function testAddLiteralPart()
     {
         $part = new SplitParameterToken($this->charsetConverter, 'name');
         $part->addPart('Khal Drogo', false, 0);
         $this->assertEquals('Khal Drogo', $part->getValue());
     }
-    
+
     public function testAddMultipleLiteralParts()
     {
         $part = new SplitParameterToken($this->charsetConverter, 'name');
@@ -56,7 +56,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
         $part->addPart('Drogo', false, 1);
         $this->assertEquals('Khal Drogo', $part->getValue());
     }
-    
+
     public function testAddUnsortedMultipleLiteralParts()
     {
         $part = new SplitParameterToken($this->charsetConverter, 'name');
@@ -65,7 +65,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
         $part->addPart('go', false, 2);
         $this->assertEquals('Khal Drogo', $part->getValue());
     }
-    
+
     public function testAddEncodedPart()
     {
         $this->charsetConverter->expects($this->once())
@@ -76,7 +76,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
         $part->addPart('Khal%20Drogo', true, 0);
         $this->assertEquals('Khal Drogo', $part->getValue());
     }
-    
+
     public function testAddMultiEncodedPart()
     {
         $this->charsetConverter->expects($this->once())
@@ -85,7 +85,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
                 'Khal Drogo, Ruler of his Khalisar', 'ISO-8859-1', 'UTF-8'
             )
             ->willReturn('Khal Drogo, Ruler of his Khalisar');
-        
+
         $part = new SplitParameterToken($this->charsetConverter, 'name');
         $part->addPart('Khal%20Drogo,%20', true, 0);
         $part->addPart('Ruler%20of%20', true, 1);
@@ -93,7 +93,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
         $part->addPart('Khalisar', true, 3);
         $this->assertEquals('Khal Drogo, Ruler of his Khalisar', $part->getValue());
     }
-    
+
     public function testAddUnsortedMultiEncodedPart()
     {
         $this->charsetConverter->expects($this->once())
@@ -102,7 +102,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
                 'Khal Drogo, Ruler of his Khalisar', 'ISO-8859-1', 'UTF-8'
             )
             ->willReturn('Khal Drogo, Ruler of his Khalisar');
-        
+
         $part = new SplitParameterToken($this->charsetConverter, 'name');
         $part->addPart('Khalisar', true, 3);
         $part->addPart('Khal%20Drogo,%20', true, 0);
@@ -110,7 +110,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
         $part->addPart('Ruler%20of%20', true, 1);
         $this->assertEquals('Khal Drogo, Ruler of his Khalisar', $part->getValue());
     }
-    
+
     public function testAddUnsortedMultiEncodedPartWithLanguage()
     {
         $this->charsetConverter->expects($this->once())
@@ -119,7 +119,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
                 'Khal Drogo, Ruler of his Khalisar', 'us-ascii', 'UTF-8'
             )
             ->willReturn('Khal Drogo, Ruler of his Khalisar');
-        
+
         $part = new SplitParameterToken($this->charsetConverter, 'name');
         $part->addPart('Khalisar', true, 3);
         $part->addPart('us-ascii\'dothraki-LHAZ\'Khal%20Drogo,%20', true, 0);
@@ -128,7 +128,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Khal Drogo, Ruler of his Khalisar', $part->getValue());
         $this->assertEquals('dothraki-LHAZ', $part->getLanguage());
     }
-    
+
     public function testLanguageNotSetOnNonZeroPart()
     {
         $this->charsetConverter->expects($this->once())
@@ -137,7 +137,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
                 'Khal Drogo, Ruler of his Khalisar', 'us-ascii', 'UTF-8'
             )
             ->willReturn('Khal Drogo, Ruler of his Khalisar');
-        
+
         $part = new SplitParameterToken($this->charsetConverter, 'name');
         $part->addPart('Khalisar', true, 3);
         $part->addPart('us-ascii\'dothraki-LHAZ\'Khal%20Drogo,%20', true, 0);
@@ -146,7 +146,7 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Khal Drogo, Ruler of his Khalisar', $part->getValue());
         $this->assertEquals('dothraki-LHAZ', $part->getLanguage());
     }
-    
+
     public function testAddMixedEncodedAndNonEncodedCombinesCharsetConversion()
     {
         $this->charsetConverter->expects($this->exactly(2))
@@ -156,16 +156,16 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
                 [ 'Khalisar', 'us-ascii', 'UTF-8' ]
             )
             ->willReturnOnConsecutiveCalls('Khal Drogo, Ruler of ', 'Khalisar');
-        
+
         $part = new SplitParameterToken($this->charsetConverter, 'name');
         $part->addPart('us-ascii\'dothraki-LHAZ\'Khal%20Drogo,%20', true, 0);
         $part->addPart('Ruler%20of%20', true, 1);
         $part->addPart('his ', false, 2);
         $part->addPart('Khalisar', true, 3);
-        
+
         $this->assertEquals('Khal Drogo, Ruler of his Khalisar', $part->getValue());
     }
-    
+
     public function testAddUnsortedMixedEncodedAndNonEncodedCombinesCharsetConversion()
     {
         $this->charsetConverter->expects($this->exactly(2))
@@ -175,13 +175,13 @@ class SplitParameterTokenTest extends PHPUnit_Framework_TestCase
                 [ 'Khalisar', 'us-ascii', 'UTF-8' ]
             )
             ->willReturnOnConsecutiveCalls('Khal Drogo, Ruler of ', 'Khalisar');
-        
+
         $part = new SplitParameterToken($this->charsetConverter, 'name');
         $part->addPart('Khalisar', true, 3);
         $part->addPart('Ruler%20of%20', true, 1);
         $part->addPart('us-ascii\'dothraki-LHAZ\'Khal%20Drogo,%20', true, 0);
         $part->addPart('his ', false, 2);
-        
+
         $this->assertEquals('Khal Drogo, Ruler of his Khalisar', $part->getValue());
     }
 }

--- a/tests/MailMimeParser/Header/Part/TokenTest.php
+++ b/tests/MailMimeParser/Header/Part/TokenTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of TokenTest
@@ -12,15 +12,15 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\Part\HeaderPart
  * @author Zaahid Bateson
  */
-class TokenTest extends PHPUnit_Framework_TestCase
+class TokenTest extends TestCase
 {
     private $charsetConverter;
-    
+
     public function setUp()
     {
         $this->charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter');
     }
-    
+
     public function testInstance()
     {
         $token = new Token($this->charsetConverter, 'testing');
@@ -28,14 +28,14 @@ class TokenTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('testing', $token->getValue());
         $this->assertEquals('testing', strval($token));
     }
-    
+
     public function testSpaceTokenValue()
     {
         $token = new Token($this->charsetConverter, ' ');
         $this->assertTrue($token->ignoreSpacesBefore());
         $this->assertTrue($token->ignoreSpacesAfter());
     }
-    
+
     public function testNonSpaceTokenValue()
     {
         $token = new Token($this->charsetConverter, 'Anything');

--- a/tests/MailMimeParser/Header/SubjectHeaderTest.php
+++ b/tests/MailMimeParser/Header/SubjectHeaderTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Header;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of SubjectHeader
@@ -12,10 +12,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Header\AbstractHeader
  * @author Zaahid Bateson
  */
-class SubjectHeaderTest extends PHPUnit_Framework_TestCase
+class SubjectHeaderTest extends TestCase
 {
     protected $consumerService;
-    
+
     protected function setUp()
     {
         $charsetConverter = $this->getMock('ZBateson\StreamDecorators\Util\CharsetConverter', ['__toString']);
@@ -23,7 +23,7 @@ class SubjectHeaderTest extends PHPUnit_Framework_TestCase
         $mlpf = $this->getMock('ZBateson\MailMimeParser\Header\Part\MimeLiteralPartFactory', ['__toString'], [$charsetConverter]);
         $this->consumerService = $this->getMock('ZBateson\MailMimeParser\Header\Consumer\ConsumerService', ['__toString'], [$pf, $mlpf]);
     }
-    
+
     public function testParsing()
     {
         $header = new SubjectHeader($this->consumerService, 'Hunted-By', 'Hunter S. Thompson');
@@ -32,7 +32,7 @@ class SubjectHeaderTest extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $header->getParts());
         $this->assertEquals('Hunted-By', $header->getName());
     }
-    
+
     public function testMultilineMimeParts()
     {
         $header = new SubjectHeader($this->consumerService, 'Hunted-By', '=?US-ASCII?Q?Hunt?=
@@ -40,16 +40,16 @@ class SubjectHeaderTest extends PHPUnit_Framework_TestCase
              =?US-ASCII?Q?Thompson?=');
         $this->assertEquals('Hunter S. Thompson', $header->getValue());
     }
-    
+
     public function testMultilineMimePartWithParentheses()
     {
         $header = new SubjectHeader($this->consumerService, 'Hunted-By', ' =?koi8-r?B?9MXIzsnexdPLycUg0sHCz9TZIChFUlAg58HMwcvUycvBIMkg79TexdTZIPTk?=
             =?koi8-r?Q?)?=');
         $this->assertEquals('Технические работы (ERP Галактика и Отчеты ТД)', $header->getValue());
     }
-    
+
     /**
-     * 
+     *
      * @covers ZBateson\MailMimeParser\Header\Consumer\QuotedStringConsumer::isStartToken
      * @covers ZBateson\MailMimeParser\Header\Consumer\QuotedStringConsumer::isEndToken
      */
@@ -62,7 +62,7 @@ class SubjectHeaderTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals('"Dwayne \"The Rock\"" Jackson (main actor)', $header->getValue());
     }
-    
+
     public function testCommentBetweenParts()
     {
         $header = new SubjectHeader(
@@ -72,7 +72,7 @@ class SubjectHeaderTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals('Dwayne (The Rock) Jackson', $header->getValue());
     }
-    
+
     public function testSubjectHeaderToString()
     {
         $header = new SubjectHeader($this->consumerService, 'Hunted-By', 'Hunter S. Thompson');

--- a/tests/MailMimeParser/IntegrationTests/EmailFunctionalTest.php
+++ b/tests/MailMimeParser/IntegrationTests/EmailFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\IntegrationTests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ZBateson\MailMimeParser\MailMimeParser;
 use ZBateson\MailMimeParser\Message;
 use ZBateson\MailMimeParser\Message\Part\MimePart;
@@ -15,7 +15,7 @@ use DateTime;
  * @group EmailFunctionalTest
  * @author Zaahid Bateson
  */
-class EmailFunctionalTest extends PHPUnit_Framework_TestCase
+class EmailFunctionalTest extends TestCase
 {
     private $parser;
     private $messageDir;

--- a/tests/MailMimeParser/IntegrationTests/ParserHeadersIntegrationTest.php
+++ b/tests/MailMimeParser/IntegrationTests/ParserHeadersIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\IntegrationTests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ZBateson\MailMimeParser\MailMimeParser;
 
 /**
@@ -12,7 +12,7 @@ use ZBateson\MailMimeParser\MailMimeParser;
  * @coversNothing
  * @author Zaahid Bateson
  */
-class ParserHeadersIntegrationTest extends PHPUnit_Framework_TestCase
+class ParserHeadersIntegrationTest extends TestCase
 {
     public function testParsingBasicHeaders()
     {
@@ -25,7 +25,7 @@ class ParserHeadersIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('More than two lines of text for a header', $message->getHeaderValue('FiFtH'));
         $this->assertNull($message->getHeaderValue('Body'));
     }
-    
+
     public function testParsingHeadersWithLFOnlyAndNoBody()
     {
         $parser = new MailMimeParser();
@@ -35,7 +35,7 @@ class ParserHeadersIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('With Value', $message->getHeaderValue('Invalid Header'));
         $this->assertEquals('Why not?', $message->getHeaderValue('No-Body'));
     }
-    
+
     public function testParsingHeadersWithLFOnlyAndInvalidHeaders()
     {
         $parser = new MailMimeParser();
@@ -47,7 +47,7 @@ class ParserHeadersIntegrationTest extends PHPUnit_Framework_TestCase
             $message->getHeaderValue('Followed-by-a-long-header-line')
         );
     }
-    
+
     public function testParsingHeadersWithEncoding()
     {
         $parser = new MailMimeParser();
@@ -56,16 +56,16 @@ class ParserHeadersIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('muzner@example.com', $message->getHeaderValue('To'));
         $this->assertEquals('Müller Müzner', $message->getHeader('To')->getPersonName());
         $this->assertEquals('في إيه يا باشا', $message->getHeaderValue('Other'));
-        
+
         $parts = $message->getHeader('From')->getParts();
         $this->assertEquals('jsnow@example.com', $parts[0]->getEmail());
         $this->assertEquals('Jon Snow', $parts[0]->getName());
         $this->assertEquals('muzner@example.com', $parts[1]->getEmail());
         $this->assertEquals('Müller Müzner', $parts[1]->getName());
-        
+
         $this->assertEquals('Andreas Müzner', $message->getHeader('Cc')->getPersonName());
         $this->assertEquals('Andreas Müzner', $message->getHeader('Bcc')->getPersonName());
-        
+
         $this->assertEquals('Технические работы (ERP Галактика и Отчеты ТД)', $message->getHeaderValue('Test'));
     }
 }

--- a/tests/MailMimeParser/MailMimeParserTest.php
+++ b/tests/MailMimeParser/MailMimeParserTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of MailMimeParserTest
@@ -11,31 +11,31 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\MailMimeParser
  * @author Zaahid Bateson
  */
-class MailMimeParserTest extends PHPUnit_Framework_TestCase
+class MailMimeParserTest extends TestCase
 {
     public function testConstructMailMimeParser()
     {
         $mmp = new MailMimeParser();
         $this->assertNotNull($mmp);
     }
-    
+
     public function testParseFromHandle()
     {
         $mmp = new MailMimeParser();
-        
+
         $handle = fopen('php://memory', 'r+');
         fwrite($handle, 'This is a test');
         rewind($handle);
-        
+
         $ret = $mmp->parse($handle);
         $this->assertNotNull($ret);
         $this->assertInstanceOf('ZBateson\MailMimeParser\Message', $ret);
     }
-    
+
     public function testParseFromString()
     {
         $mmp = new MailMimeParser();
-        
+
         $ret = $mmp->parse('This is a test');
         $this->assertNotNull($ret);
         $this->assertInstanceOf('ZBateson\MailMimeParser\Message', $ret);

--- a/tests/MailMimeParser/Message/Helper/GenericHelperTest.php
+++ b/tests/MailMimeParser/Message/Helper/GenericHelperTest.php
@@ -3,18 +3,18 @@ namespace ZBateson\MailMimeParser\Message\Helper;
 
 use GuzzleHttp\Psr7;
 use ZBateson\MailMimeParser\MailMimeParser;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * GenericHelperTest
- * 
+ *
  * @group GenericHelper
  * @group MessageHelper
  * @covers ZBateson\MailMimeParser\Message\Helper\AbstractHelper
  * @covers ZBateson\MailMimeParser\Message\Helper\GenericHelper
  * @author Zaahid Bateson
  */
-class GenericHelperTest extends PHPUnit_Framework_TestCase
+class GenericHelperTest extends TestCase
 {
     private $mockMimePartFactory;
     private $mockUUEncodedPartFactory;
@@ -32,7 +32,7 @@ class GenericHelperTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
     }
-    
+
     private function newMockMimePart()
     {
         return $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\MimePart')
@@ -179,7 +179,7 @@ class GenericHelperTest extends PHPUnit_Framework_TestCase
             ->method('attachContentStream');
         $from->expects($this->exactly(5))
             ->method('removeHeader');
-        
+
         $helper->createNewContentPartFrom($from);
     }
 
@@ -204,7 +204,7 @@ class GenericHelperTest extends PHPUnit_Framework_TestCase
         $to->expects($this->once())
             ->method('getContentStream')
             ->willReturn($toStream);
-        
+
         $to->expects($this->once())
             ->method('getChildParts')
             ->willReturn([ $child1, $child2 ]);

--- a/tests/MailMimeParser/Message/Helper/MessageHelperServiceTest.php
+++ b/tests/MailMimeParser/Message/Helper/MessageHelperServiceTest.php
@@ -1,18 +1,18 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Helper;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ZBateson\MailMimeParser\SimpleDi;
 
 /**
  * MessageHelperServiceTest
- * 
+ *
  * @group MessageHelperService
  * @group MessageHelper
  * @covers ZBateson\MailMimeParser\Message\Helper\MessageHelperService
  * @author Zaahid Bateson
  */
-class MessageHelperServiceTest extends PHPUnit_Framework_TestCase
+class MessageHelperServiceTest extends TestCase
 {
     public function testInstance()
     {

--- a/tests/MailMimeParser/Message/Helper/MultipartHelperTest.php
+++ b/tests/MailMimeParser/Message/Helper/MultipartHelperTest.php
@@ -1,18 +1,18 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Helper;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * MultipartHelperTest
- * 
+ *
  * @group MultipartHelper
  * @group MessageHelper
  * @covers ZBateson\MailMimeParser\Message\Helper\AbstractHelper
  * @covers ZBateson\MailMimeParser\Message\Helper\MultipartHelper
  * @author Zaahid Bateson
  */
-class MultipartHelperTest extends PHPUnit_Framework_TestCase
+class MultipartHelperTest extends TestCase
 {
     private $mockMimePartFactory;
     private $mockUUEncodedPartFactory;
@@ -34,7 +34,7 @@ class MultipartHelperTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
     }
-    
+
     private function newMockMimePart()
     {
         return $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\MimePart')
@@ -534,7 +534,7 @@ class MultipartHelperTest extends PHPUnit_Framework_TestCase
         $partBuilder->expects($this->once())
             ->method('createMessagePart')
             ->willReturn($attPart);
-        
+
         $resource = 'test';
         $attPart->expects($this->once())
             ->method('setContent')
@@ -545,7 +545,7 @@ class MultipartHelperTest extends PHPUnit_Framework_TestCase
 
         $helper->createAndAddPartForAttachment($message, $resource, 'test-mime', 'dispo', null);
     }
-    
+
     public function testCreateAndAddPartForAttachmentToNonMimeMessage()
     {
         $helper = $this->newMultipartHelper();
@@ -573,7 +573,7 @@ class MultipartHelperTest extends PHPUnit_Framework_TestCase
         $partBuilder->expects($this->once())
             ->method('createMessagePart')
             ->willReturn($attPart);
-        
+
         $resource = 'test';
         $attPart->expects($this->once())
             ->method('setContent')
@@ -623,7 +623,7 @@ class MultipartHelperTest extends PHPUnit_Framework_TestCase
         $message->expects($this->once())
             ->method('getTextPart')
             ->willReturn(null);
-        
+
         $partBuilder = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartBuilder')
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/MailMimeParser/Message/Helper/PrivacyHelperTest.php
+++ b/tests/MailMimeParser/Message/Helper/PrivacyHelperTest.php
@@ -2,7 +2,7 @@
 namespace ZBateson\MailMimeParser\Message\Helper;
 
 use GuzzleHttp\Psr7;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PrivacyHelperTest
@@ -13,7 +13,7 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Message\Helper\PrivacyHelper
  * @author Zaahid Bateson
  */
-class PrivacyHelperTest extends PHPUnit_Framework_TestCase
+class PrivacyHelperTest extends TestCase
 {
     private $mockMimePartFactory;
     private $mockUUEncodedPartFactory;
@@ -173,7 +173,7 @@ class PrivacyHelperTest extends PHPUnit_Framework_TestCase
 
         $message = $this->newMockMessage();
         $messagePart = $this->newMockMimePart();
-        
+
         $message->expects($this->once())
             ->method('getContentType')
             ->willReturn('text/plain');

--- a/tests/MailMimeParser/Message/MessageFactoryTest.php
+++ b/tests/MailMimeParser/Message/MessageFactoryTest.php
@@ -1,21 +1,21 @@
 <?php
 namespace ZBateson\MailMimeParser\Message;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 
 /**
  * MessageFactoryTest
- * 
+ *
  * @group MessageFactory
  * @group Message
  * @covers ZBateson\MailMimeParser\Message\MessageFactory
  * @author Zaahid Bateson
  */
-class MessageFactoryTest extends PHPUnit_Framework_TestCase
+class MessageFactoryTest extends TestCase
 {
     protected $messageFactory;
-    
+
     protected function setUp()
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
@@ -32,10 +32,10 @@ class MessageFactoryTest extends PHPUnit_Framework_TestCase
         $mockHelperService = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Helper\MessageHelperService')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $mockpsfmfactory->method('newInstance')
             ->willReturn($mockpsfm);
-        
+
         $this->messageFactory = new MessageFactory(
             $mocksdf,
             $mockpsfmfactory,
@@ -43,7 +43,7 @@ class MessageFactoryTest extends PHPUnit_Framework_TestCase
             $mockHelperService
         );
     }
-    
+
     public function testNewInstance()
     {
         $partBuilder = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartBuilder')

--- a/tests/MailMimeParser/Message/MessageParserTest.php
+++ b/tests/MailMimeParser/Message/MessageParserTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Message;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 use org\bovigo\vfs\vfsStream;
 
@@ -13,7 +13,7 @@ use org\bovigo\vfs\vfsStream;
  * @covers ZBateson\MailMimeParser\Message\MessageParser
  * @author Zaahid Bateson
  */
-class MessageParserTest extends PHPUnit_Framework_TestCase
+class MessageParserTest extends TestCase
 {
     protected $partFactoryService;
     protected $partBuilderFactory;
@@ -22,43 +22,43 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
     protected $uuEncodedPartFactory;
     protected $mimePartFactory;
     protected $vfs;
-    
+
     public function setUp()
     {
         $this->vfs = vfsStream::setup('root');
-        
+
         $this->partFactoryService = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\Factory\PartFactoryService')
             ->disableOriginalConstructor()
             ->getMock();
-           
+
         $this->partBuilderFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\Factory\PartBuilderFactory')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $this->partStreamRegistry = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\PartStreamRegistry')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $this->messageFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\MessageFactory')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $this->uuEncodedPartFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\Factory\UUEncodedPartFactory')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $this->mimePartFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\Factory\MimePartFactory')
             ->disableOriginalConstructor()
             ->getMock();
     }
-    
+
     protected function getMimePartMock()
     {
         return $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\MimePart')
             ->disableOriginalConstructor()
             ->getMock();
     }
-    
+
     protected function getPartBuilderMock($mimeMock = null)
     {
         if ($mimeMock === null) {
@@ -84,17 +84,17 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $parser->parse($email);
         fclose($email);
     }
-    
+
     public function testParseEmptyMessage()
     {
         $content = vfsStream::newFile('part')->at($this->vfs);
         $content->withContent('');
         $handle = fopen($content->url(), 'r');
-        
+
         $pfs = $this->partFactoryService;
         $pfs->method('getMessageFactory')
             ->willReturn($this->messageFactory);
-        
+
         $pb = $this->getPartBuilderMock();
         $pb->expects($this->once())
             ->method('setStreamPartStartPos')
@@ -112,18 +112,18 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pb->expects($this->once())
             ->method('setStreamPartEndPos')
             ->with(0);
-        
+
         $pbf = $this->partBuilderFactory;
         $pbf->method('newPartBuilder')
             ->willReturn($pb);
-        
+
         $mp = new MessageParser($pfs, $pbf, $this->partStreamRegistry);
         $message = $mp->parse(Psr7\stream_for($handle));
         $this->assertNotNull($message);
-        
+
         fclose($handle);
     }
-    
+
     public function testParseSimpleNonMimeMessage()
     {
         $email =
@@ -133,15 +133,15 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $email .= "Dear Albert,\r\n\r\nAfter our wonderful time together, it's unfortunate I know, but I expect payment\r\n"
             . "for all services hereby rendered.\r\n\r\nYours faithfully,\r\nKandice Waterskyfalls";
         $endPos = strlen($email);
-        
+
         $content = vfsStream::newFile('part')->at($this->vfs);
         $content->withContent($email);
         $handle = fopen($content->url(), 'r');
-        
+
         $pfs = $this->partFactoryService;
         $pfs->method('getMessageFactory')
             ->willReturn($this->messageFactory);
-        
+
         $pb = $this->getPartBuilderMock();
         $pb->expects($this->once())
             ->method('setStreamPartStartPos')
@@ -168,18 +168,18 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pb->expects($this->once())
             ->method('setStreamPartEndPos')
             ->with($endPos);
-        
+
         $pbf = $this->partBuilderFactory;
         $pbf->method('newPartBuilder')
             ->willReturn($pb);
-        
+
         $mp = new MessageParser($pfs, $pbf, $this->partStreamRegistry);
         $message = $mp->parse(Psr7\stream_for($handle));
         $this->assertNotNull($message);
-        
+
         fclose($handle);
     }
-    
+
     public function testParseMessageWithUUEncodedAttachments()
     {
         $email =
@@ -198,18 +198,18 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
             . 'No, Tommy. ... It\'s tiptop. It\'s just I\'m not sure about the colour.'
             . "\r\nend\r\n";
         $endEmailPos = strlen($email);
-        
+
         $content = vfsStream::newFile('part')->at($this->vfs);
         $content->withContent($email);
         $handle = fopen($content->url(), 'r');
-        
+
         $pfs = $this->partFactoryService;
         $pfs->method('getMessageFactory')
             ->willReturn($this->messageFactory);
         $pfs->expects($this->exactly(2))
             ->method('getUUEncodedPartFactory')
             ->willReturn($this->uuEncodedPartFactory);
-        
+
         $pbm = $this->getPartBuilderMock();
         $pbm->expects($this->once())
             ->method('setStreamPartStartPos')
@@ -238,7 +238,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pbm->expects($this->once())
             ->method('setStreamPartEndPos')
             ->with($endEmailPos);
-        
+
         $pba1 = $this->getPartBuilderMock();
         $pba1->expects($this->once())
             ->method('setStreamPartStartPos')
@@ -256,7 +256,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
             ->method('setStreamPartAndContentEndPos')
             ->withConsecutive([$this->anything()], [$this->anything()],
                 [$this->anything()], [$endPos]);
-        
+
         $pba2 = $this->getPartBuilderMock();
         $pba2->expects($this->once())
             ->method('setStreamPartStartPos')
@@ -274,25 +274,25 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
             ->method('setStreamPartAndContentEndPos')
             ->withConsecutive([$this->anything()], [$this->anything()],
                 [$endEmailPos]);
-        
+
         $pbm->expects($this->exactly(2))
             ->method('addChild')
             ->withConsecutive([$pba1], [$pba2]);
-        
+
         $pbf = $this->partBuilderFactory;
         $pbf->expects($this->exactly(3))
             ->method('newPartBuilder')
             ->willReturnOnConsecutiveCalls(
                 $pbm, $pba1, $pba2
             );
-        
+
         $mp = new MessageParser($pfs, $pbf, $this->partStreamRegistry);
         $message = $mp->parse(Psr7\stream_for($handle));
         $this->assertNotNull($message);
-        
+
         fclose($handle);
     }
-    
+
     public function testParseSimpleMimeMessage()
     {
         $email =
@@ -303,15 +303,15 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $email .= "Dear Albert,\r\n\r\nAfter our wonderful time together, it's unfortunate I know, but I expect payment\r\n"
             . "for all services hereby rendered.\r\n\r\nYours faithfully,\r\nKandice Waterskyfalls";
         $endPos = strlen($email);
-        
+
         $content = vfsStream::newFile('part')->at($this->vfs);
         $content->withContent($email);
         $handle = fopen($content->url(), 'r');
-        
+
         $pfs = $this->partFactoryService;
         $pfs->method('getMessageFactory')
             ->willReturn($this->messageFactory);
-        
+
         $pb = $this->getPartBuilderMock();
         $pb->expects($this->once())
             ->method('setStreamPartStartPos')
@@ -337,18 +337,18 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pb->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($endPos);
-        
+
         $pbf = $this->partBuilderFactory;
         $pbf->method('newPartBuilder')
             ->willReturn($pb);
-        
+
         $mp = new MessageParser($pfs, $pbf, $this->partStreamRegistry);
         $message = $mp->parse(Psr7\stream_for($handle));
         $this->assertNotNull($message);
-        
+
         fclose($handle);
     }
-    
+
     public function testParseMultipartAlternativeMessage()
     {
         $email =
@@ -356,7 +356,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
             . " boundary=balderdash\r\n"
             . "Subject: I'm a tiny little wee teapot\r\n"
             . "\r\n";
-        
+
         $messagePartStart = strlen($email);
         $email .= "--balderdash\r\n";
         $partOneStart = strlen($email);
@@ -378,18 +378,18 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $partTwoEnd = strlen($email);
         $email .= "\r\n--balderdash--\r\n\r\n";
         $emailEnd = strlen($email);
-        
+
         $content = vfsStream::newFile('part')->at($this->vfs);
         $content->withContent($email);
         $handle = fopen($content->url(), 'r');
-        
+
         $pfs = $this->partFactoryService;
         $pfs->method('getMessageFactory')
             ->willReturn($this->messageFactory);
         $pfs->expects($this->exactly(3))
             ->method('getMimePartFactory')
             ->willReturn($this->mimePartFactory);
-        
+
         $pbm = $this->getPartBuilderMock();
         $pbm->expects($this->once())
             ->method('setStreamPartStartPos')
@@ -452,7 +452,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pba1->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($partOneEnd);
-        
+
         $pba2 = $this->getPartBuilderMock();
         $pba2->expects($this->once())
             ->method('canHaveHeaders')
@@ -478,7 +478,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pba2->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($partTwoEnd);
-        
+
         $pba3 = $this->getPartBuilderMock();
         $pba3->expects($this->once())
             ->method('canHaveHeaders')
@@ -495,45 +495,45 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pba3->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($emailEnd);
-        
+
         $pbm->expects($this->exactly(3))
             ->method('addChild')
             ->withConsecutive([$pba1], [$pba2], [$pba3]);
-        
+
         $pbf = $this->partBuilderFactory;
         $pbf->expects($this->exactly(4))
             ->method('newPartBuilder')
             ->willReturnOnConsecutiveCalls(
                 $pbm, $pba1, $pba2, $pba3
             );
-        
+
         $mp = new MessageParser($pfs, $pbf, $this->partStreamRegistry);
         $message = $mp->parse(Psr7\stream_for($handle));
         $this->assertNotNull($message);
-        
+
         fclose($handle);
     }
-    
+
     public function testParseMultipartMixedWithAlternativeMessage()
     {
         $email =
             "Content-Type: multipart/mixed; boundary=balderdash\r\n"
             . "Subject: Of mice and men\r\n"
             . "\r\n";
-        
+
         $messagePartStart = strlen($email);
         $email .= "This existed for nought - hidden from view";
         $messagePartEnd = strlen($email);
-        
+
         $email .= "\r\n--balderdash\r\n";
         $altPartStart = strlen($email);
         $email .= "Content-Type: multipart/alternative; boundary=gobbledygook\r\n"
             . "\r\n";
-        
+
         $altPartContentStart = strlen($email);
         $email .= "A line to fool the senses was created... and it was this line";
         $altPartContentEnd = strlen($email);
-        
+
         $email .= "\r\n--gobbledygook\r\n";
         $partOneStart = strlen($email);
         $email .= "Content-Type: text/html\r\n"
@@ -574,14 +574,14 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $content = vfsStream::newFile('part')->at($this->vfs);
         $content->withContent($email);
         $handle = fopen($content->url(), 'r');
-        
+
         $pfs = $this->partFactoryService;
         $pfs->method('getMessageFactory')
             ->willReturn($this->messageFactory);
         $pfs->expects($this->exactly(7))
             ->method('getMimePartFactory')
             ->willReturn($this->mimePartFactory);
-        
+
         $pbm = $this->getPartBuilderMock();
         $pbm->expects($this->once())
             ->method('setStreamPartStartPos')
@@ -617,7 +617,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pbm->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($messagePartEnd);
-        
+
         $pbAlt = $this->getPartBuilderMock();
         $pbAlt->expects($this->once())
             ->method('canHaveHeaders')
@@ -650,7 +650,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pbAlt->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($altPartContentEnd);
-        
+
         $pba1 = $this->getPartBuilderMock();
         $pba1->expects($this->once())
             ->method('canHaveHeaders')
@@ -682,7 +682,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pba1->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($partOneEnd);
-        
+
         $pba2 = $this->getPartBuilderMock();
         $pba2->expects($this->once())
             ->method('canHaveHeaders')
@@ -714,7 +714,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pba2->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($partTwoEnd);
-        
+
         $pba3 = $this->getPartBuilderMock();
         $pba3->expects($this->once())
             ->method('canHaveHeaders')
@@ -729,7 +729,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
             ->method('setEndBoundaryFound')
             ->with('--balderdash')
             ->willReturn(true);
-        
+
         $pba4 = $this->getPartBuilderMock();
         $pba4->expects($this->once())
             ->method('canHaveHeaders')
@@ -759,7 +759,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pba4->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($partThreeEnd);
-        
+
         $pba5 = $this->getPartBuilderMock();
         $pba5->expects($this->once())
             ->method('canHaveHeaders')
@@ -791,7 +791,7 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         $pba5->expects($this->once())
             ->method('setStreamPartAndContentEndPos')
             ->with($partFourEnd);
-        
+
         $pba6 = $this->getPartBuilderMock();
         $pba6->expects($this->once())
             ->method('canHaveHeaders')
@@ -807,25 +807,25 @@ class MessageParserTest extends PHPUnit_Framework_TestCase
         // no extra trailling characters
         $pba6->expects($this->never())
             ->method('setEndBoundaryFound');
-        
+
         $pbm->expects($this->any())
             ->method('addChild')
             ->withConsecutive([$pbAlt], [$pba4], [$pba5], [$pba6]);
         $pbAlt->expects($this->exactly(3))
             ->method('addChild')
             ->withConsecutive([$pba1], [$pba2], [$pba3]);
-        
+
         $pbf = $this->partBuilderFactory;
         $pbf->expects($this->exactly(8))
             ->method('newPartBuilder')
             ->willReturnOnConsecutiveCalls(
                 $pbm, $pbAlt, $pba1, $pba2, $pba3, $pba4, $pba5, $pba6
             );
-        
+
         $mp = new MessageParser($pfs, $pbf, $this->partStreamRegistry);
         $message = $mp->parse(Psr7\stream_for($handle));
         $this->assertNotNull($message);
-        
+
         fclose($handle);
     }
 }

--- a/tests/MailMimeParser/Message/Part/Factory/MimePartFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/MimePartFactoryTest.php
@@ -1,23 +1,23 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part\Factory;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 
 /**
  * MimePartFactoryTest
- * 
+ *
  * @group MimePartFactory
  * @group MessagePart
  * @covers ZBateson\MailMimeParser\Message\Part\Factory\MimePartFactory
  * @covers ZBateson\MailMimeParser\Message\Part\Factory\MessagePartFactory
  * @author Zaahid Bateson
  */
-class MimePartFactoryTest extends PHPUnit_Framework_TestCase
+class MimePartFactoryTest extends TestCase
 {
     protected $mimePartFactory;
     protected $partFilterFactory;
-    
+
     protected function setUp()
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
@@ -34,19 +34,19 @@ class MimePartFactoryTest extends PHPUnit_Framework_TestCase
         $psfmFactory
             ->method('newInstance')
             ->willReturn($psfm);
-        
+
         $mockFilterFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\PartFilterFactory')
             ->disableOriginalConstructor()
             ->getMock();
         $this->mimePartFactory = new MimePartFactory($mocksdf, $psfmFactory, $mockFilterFactory);
     }
-    
+
     public function testNewInstance()
     {
         $partBuilder = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartBuilder')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $part = $this->mimePartFactory->newInstance(
             $partBuilder,
             Psr7\stream_for('test')

--- a/tests/MailMimeParser/Message/Part/Factory/NonMimePartFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/NonMimePartFactoryTest.php
@@ -1,22 +1,22 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part\Factory;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 
 /**
  * NonMimePartFactoryTest
- * 
+ *
  * @group NonMimePartFactory
  * @group MessagePart
  * @covers ZBateson\MailMimeParser\Message\Part\Factory\NonMimePartFactory
  * @covers ZBateson\MailMimeParser\Message\Part\Factory\MessagePartFactory
  * @author Zaahid Bateson
  */
-class NonMimePartFactoryTest extends PHPUnit_Framework_TestCase
+class NonMimePartFactoryTest extends TestCase
 {
     protected $nonMimePartFactory;
-    
+
     protected function setUp()
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
@@ -33,16 +33,16 @@ class NonMimePartFactoryTest extends PHPUnit_Framework_TestCase
         $psfmFactory
             ->method('newInstance')
             ->willReturn($psfm);
-        
+
         $this->nonMimePartFactory = new NonMimePartFactory($mocksdf, $psfmFactory);
     }
-    
+
     public function testNewInstance()
     {
         $partBuilder = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartBuilder')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $part = $this->nonMimePartFactory->newInstance(
             $partBuilder,
             Psr7\stream_for('test')

--- a/tests/MailMimeParser/Message/Part/Factory/PartBuilderFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/PartBuilderFactoryTest.php
@@ -1,20 +1,20 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part\Factory;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PartBuilderFactoryTest
- * 
+ *
  * @group PartBuilderFactory
  * @group MessagePart
  * @covers ZBateson\MailMimeParser\Message\Part\Factory\PartBuilderFactory
  * @author Zaahid Bateson
  */
-class PartBuilderFactoryTest extends PHPUnit_Framework_TestCase
+class PartBuilderFactoryTest extends TestCase
 {
     protected $partBuilderFactory;
-    
+
     protected function setUp()
     {
         $mockHeaderFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Header\HeaderFactory')
@@ -23,13 +23,13 @@ class PartBuilderFactoryTest extends PHPUnit_Framework_TestCase
             ->getMock();
         $this->partBuilderFactory = new PartBuilderFactory($mockHeaderFactory, 'amazon');
     }
-    
+
     public function testNewInstance()
     {
         $mockMessagePartFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\Factory\MessagePartFactory')
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        
+
         $partBuilder = $this->partBuilderFactory->newPartBuilder($mockMessagePartFactory);
         $this->assertInstanceOf(
             '\ZBateson\MailMimeParser\Message\Part\PartBuilder',

--- a/tests/MailMimeParser/Message/Part/Factory/PartFactoryServiceTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/PartFactoryServiceTest.php
@@ -1,18 +1,18 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part\Factory;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ZBateson\MailMimeParser\SimpleDi;
 
 /**
  * PartFactoryServiceTest
- * 
+ *
  * @group PartFactoryService
  * @group MessagePart
  * @covers ZBateson\MailMimeParser\Message\Part\Factory\PartFactoryService
  * @author Zaahid Bateson
  */
-class PartFactoryServiceTest extends PHPUnit_Framework_TestCase
+class PartFactoryServiceTest extends TestCase
 {
     public function testInstance()
     {
@@ -21,13 +21,13 @@ class PartFactoryServiceTest extends PHPUnit_Framework_TestCase
 
         $messageFactory = $partFactoryService->getMessageFactory();
         $this->assertInstanceOf('ZBateson\MailMimeParser\Message\MessageFactory', $messageFactory);
-        
+
         $mimePartFactory = $partFactoryService->getMimePartFactory();
         $this->assertInstanceOf('ZBateson\MailMimeParser\Message\Part\Factory\MimePartFactory', $mimePartFactory);
-        
+
         $nonMimePartFactory = $partFactoryService->getNonMimePartFactory();
         $this->assertInstanceOf('ZBateson\MailMimeParser\Message\Part\Factory\NonMimePartFactory', $nonMimePartFactory);
-        
+
         $uuEncodedPartFactory = $partFactoryService->getUUEncodedPartFactory();
         $this->assertInstanceOf('ZBateson\MailMimeParser\Message\Part\Factory\UUEncodedPartFactory', $uuEncodedPartFactory);
     }

--- a/tests/MailMimeParser/Message/Part/Factory/PartStreamFilterManagerFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/PartStreamFilterManagerFactoryTest.php
@@ -1,20 +1,20 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part\Factory;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PartStreamFilterManagerFactoryTest
- * 
+ *
  * @group PartStreamFilterManagerFactory
  * @group MessagePart
  * @covers ZBateson\MailMimeParser\Message\Part\Factory\PartStreamFilterManagerFactory
  * @author Zaahid Bateson
  */
-class PartStreamFilterManagerFactoryTest extends PHPUnit_Framework_TestCase
+class PartStreamFilterManagerFactoryTest extends TestCase
 {
     protected $partStreamFilterManagerFactory;
-    
+
     protected function setUp()
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
@@ -23,7 +23,7 @@ class PartStreamFilterManagerFactoryTest extends PHPUnit_Framework_TestCase
             $mocksdf
         );
     }
-    
+
     public function testNewInstance()
     {
         $manager = $this->partStreamFilterManagerFactory->newInstance();

--- a/tests/MailMimeParser/Message/Part/Factory/UUEncodedPartFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/UUEncodedPartFactoryTest.php
@@ -1,22 +1,22 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part\Factory;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 
 /**
  * UUEncodedPartFactoryTest
- * 
+ *
  * @group UUEncodedPartFactory
  * @group MessagePart
  * @covers ZBateson\MailMimeParser\Message\Part\Factory\UUEncodedPartFactory
  * @covers ZBateson\MailMimeParser\Message\Part\Factory\MessagePartFactory
  * @author Zaahid Bateson
  */
-class UUEncodedPartFactoryTest extends PHPUnit_Framework_TestCase
+class UUEncodedPartFactoryTest extends TestCase
 {
     protected $uuEncodedPartFactory;
-    
+
     protected function setUp()
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
@@ -33,16 +33,16 @@ class UUEncodedPartFactoryTest extends PHPUnit_Framework_TestCase
         $psfmFactory
             ->method('newInstance')
             ->willReturn($psfm);
-        
+
         $this->uuEncodedPartFactory = new UUEncodedPartFactory($mocksdf, $psfmFactory);
     }
-    
+
     public function testNewInstance()
     {
         $partBuilder = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartBuilder')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $part = $this->uuEncodedPartFactory->newInstance(
             $partBuilder,
             Psr7\stream_for('test')

--- a/tests/MailMimeParser/Message/Part/MessagePartTest.php
+++ b/tests/MailMimeParser/Message/Part/MessagePartTest.php
@@ -1,24 +1,24 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\StreamWrapper;
 use Exception;
 
 /**
  * MessagePartFactoryTest
- * 
+ *
  * @group MessagePartClass
  * @group MessagePart
  * @covers ZBateson\MailMimeParser\Message\Part\MessagePart
  * @author Zaahid Bateson
  */
-class MessagePartTest extends PHPUnit_Framework_TestCase
+class MessagePartTest extends TestCase
 {
     protected $partStreamFilterManager;
     protected $streamFactory;
-    
+
     protected function setUp()
     {
         $psf = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartStreamFilterManager')
@@ -30,7 +30,7 @@ class MessagePartTest extends PHPUnit_Framework_TestCase
         $this->partStreamFilterManager = $psf;
         $this->streamFactory = $sf;
     }
-    
+
     private function getMessagePart($handle = 'habibi', $contentHandle = null)
     {
         if ($contentHandle !== null) {
@@ -50,7 +50,7 @@ class MessagePartTest extends PHPUnit_Framework_TestCase
             [ $this->partStreamFilterManager, $this->streamFactory, Psr7\stream_for($handle), $contentHandle ]
         );
     }
-    
+
     public function testNewInstance()
     {
         $messagePart = $this->getMessagePart();
@@ -71,7 +71,7 @@ class MessagePartTest extends PHPUnit_Framework_TestCase
         $handle = $messagePart->getResourceHandle();
         $this->assertEquals('mucha agua', stream_get_contents($handle));
     }
-    
+
     public function testContentStreamAndHandle()
     {
         $messagePart = $this->getMessagePart('Que tonta', 'Que tonto');
@@ -79,7 +79,7 @@ class MessagePartTest extends PHPUnit_Framework_TestCase
             ->willReturn('wubalubadub-duuuuub');
         $messagePart->method('getCharset')
             ->willReturn('wigidiwamwamwazzle');
-        
+
         $this->assertTrue($messagePart->hasContent());
         $this->assertEquals('Que tonto', $messagePart->getContentStream()->getContents());
         $this->assertEquals('Que tonto', stream_get_contents($messagePart->getContentResourceHandle()));
@@ -110,7 +110,7 @@ class MessagePartTest extends PHPUnit_Framework_TestCase
         $messagePart->detachContentStream();
         $this->assertEquals('Much success', $messagePart->getStream());
     }
-    
+
     public function testContentStreamHandleWithCustomCharset()
     {
         $messagePart = $this->getMessagePart('Que tonta', 'Que tonto');
@@ -146,7 +146,7 @@ class MessagePartTest extends PHPUnit_Framework_TestCase
         $stream = Psr7\stream_for('test');
         $messagePart = $this->getMessagePart($stream);
         $this->assertEquals($stream, $messagePart->getStream());
-        
+
         $this->streamFactory
             ->expects($this->once())
             ->method('newMessagePartStream')
@@ -163,7 +163,7 @@ class MessagePartTest extends PHPUnit_Framework_TestCase
         $messagePart = $this->getMessagePart();
         $this->assertNull($messagePart->getFilename());
     }
-    
+
     public function testGetContent()
     {
         $messagePart = $this->getMessagePart('habibi', 'sopa di agua con rocas');
@@ -196,7 +196,7 @@ class MessagePartTest extends PHPUnit_Framework_TestCase
             ->willReturn('quoted-printable');
         $part->method('getCharset')
             ->willReturn('utf-64');
-        
+
         $new = Psr7\stream_for('updated');
         $this->partStreamFilterManager
             ->method('getContentStream')

--- a/tests/MailMimeParser/Message/Part/MimePartTest.php
+++ b/tests/MailMimeParser/Message/Part/MimePartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 
 /**
@@ -15,7 +15,7 @@ use GuzzleHttp\Psr7;
  * @covers ZBateson\MailMimeParser\Message\Part\MessagePart
  * @author Zaahid Bateson
  */
-class MimePartTest extends PHPUnit_Framework_TestCase
+class MimePartTest extends TestCase
 {
     private $mockPartStreamFilterManager;
     private $mockPartFilterFactory;
@@ -33,7 +33,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
     }
-    
+
     protected function getMockedParameterHeader($name, $value, $parameterValue = null)
     {
         $header = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
@@ -47,7 +47,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $header->method('hasParameter')->willReturn(true);
         return $header;
     }
-    
+
     protected function getMockedPartBuilder()
     {
         $hc = $this->getMockBuilder('ZBateson\MailMimeParser\Header\HeaderContainer')
@@ -60,7 +60,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
             ->willReturn($hc);
         return $pb;
     }
-    
+
     protected function getMockedPartBuilderWithChildren()
     {
         $pb = $this->getMockedPartBuilder();
@@ -69,7 +69,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
             $this->getMockedPartBuilder(),
             $this->getMockedPartBuilder()
         ];
-        
+
         $nested = $this->getMockedPartBuilder();
         $nested->method('createMessagePart')
             ->willReturn($this->newMimePart(
@@ -78,7 +78,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
             ));
         $children[0]->method('getChildren')
             ->willReturn([$nested]);
-        
+
         foreach ($children as $key => $child) {
             $child->method('createMessagePart')
                 ->willReturn($this->newMimePart(
@@ -102,7 +102,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
             $contentStream
         );
     }
-    
+
     public function testInstance()
     {
         $part = $this->newMimePart($this->getMockedPartBuilder());
@@ -110,7 +110,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZBateson\MailMimeParser\Message\Part\MimePart', $part);
         $this->assertTrue($part->isMime());
     }
-    
+
     public function testCreateChildrenAndGetChildren()
     {
         $part = $this->newMimePart($this->getMockedPartBuilderWithChildren());
@@ -125,28 +125,28 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         ];
         $this->assertEquals($children, $part->getChildParts());
     }
-    
+
     public function testCreateChildrenAndGetParts()
     {
         $part = $this->newMimePart($this->getMockedPartBuilderWithChildren(), Psr7\stream_for('habibi'));
         $this->assertEquals(5, $part->getPartCount());
-        
+
         $children = $part->getChildParts();
         $this->assertCount(3, $children);
         $nested = $children[0]->getChild(0);
-        
+
         $this->assertSame($part, $part->getPart(0));
         $this->assertSame($children[0], $part->getPart(1));
         $this->assertSame($nested, $part->getPart(2));
         $this->assertSame($children[1], $part->getPart(3));
         $this->assertSame($children[2], $part->getPart(4));
-        
+
         $this->assertEquals('habibi', stream_get_contents($part->getPart(0)->getResourceHandle()));
         $this->assertEquals('child0', stream_get_contents($part->getPart(1)->getResourceHandle()));
         $this->assertEquals('nested', stream_get_contents($part->getPart(2)->getResourceHandle()));
         $this->assertEquals('child1', stream_get_contents($part->getPart(3)->getResourceHandle()));
         $this->assertEquals('child2', stream_get_contents($part->getPart(4)->getResourceHandle()));
-        
+
         $allParts = [ $part, $children[0], $nested, $children[1], $children[2]];
         $this->assertEquals($allParts, $part->getAllParts());
     }
@@ -194,7 +194,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertSame($secondHeader, $part->getHeader($secondHeader->getName()));
         $this->assertEquals($firstHeader->getValue(), $part->getHeaderValue($firstHeader->getName()));
         $this->assertEquals($secondHeader->getValue(), $part->getHeaderValue($secondHeader->getName()));
-        
+
         $this->assertCount(2, $part->getRawHeaders());
         $this->assertEquals([[ 'First-Header', $firstHeader->getRawValue() ], [ 'Second-Header', $secondHeader->getRawValue() ]], $part->getRawHeaders());
 
@@ -371,17 +371,17 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $filterMock->expects($this->exactly(5))
             ->method('filter')
             ->willReturnOnConsecutiveCalls(false, true, false, true, false);
-        
+
         $returned = $part->getAllParts($filterMock);
         $this->assertCount(2, $returned);
         $this->assertEquals([$parts[1], $parts[3]], $returned);
     }
-    
+
     public function testGetFilteredChildParts()
     {
         $part = $this->newMimePart($this->getMockedPartBuilderWithChildren());
         $parts = $part->getAllParts();
-        
+
         $filterMock = $this->getMockBuilder('ZBateson\MailMimeParser\Message\PartFilter')
             ->disableOriginalConstructor()
             ->setMethods(['filter'])
@@ -389,12 +389,12 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $filterMock->expects($this->exactly(3))
             ->method('filter')
             ->willReturnOnConsecutiveCalls(false, true, false);
-        
+
         $returned = $part->getChildParts($filterMock);
         $this->assertCount(1, $returned);
         $this->assertEquals([$parts[3]], $returned);
     }
-    
+
     public function testGetUnsetHeader()
     {
         $part = $this->newMimePart($this->getMockedPartBuilder());
@@ -417,7 +417,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertSame($header, $part->getHeader('Content-Disposition'));
         $this->assertEquals('habibi', $part->getContentDisposition());
     }
-    
+
     public function testGetContentTransferEncoding()
     {
         $header = $this->getMockedParameterHeader('meen?', 'x-uue');
@@ -432,7 +432,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertSame($header, $part->getHeader('Content-Transfer-Encoding'));
         $this->assertEquals('x-uuencode', $part->getContentTransferEncoding());
     }
-    
+
     public function testGetCharset()
     {
         $header = $this->getMockedParameterHeader('content-type', 'text/plain', 'blah');
@@ -442,7 +442,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
             ->method('get')
             ->with('Content-Type', 0)
             ->willReturn($header);
-        
+
         $part = $this->newMimePart($pb);
         $this->assertEquals('BLAH', $part->getCharset());
     }
@@ -465,7 +465,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $part = $this->newMimePart($pb);
         $this->assertEquals('blah', $part->getFilename());
     }
-    
+
     public function testGetDefaultCharsetForTextPlainAndTextHtml()
     {
         $headerText = $this->getMockedParameterHeader('content-type', 'text/plain');
@@ -491,7 +491,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('ISO-8859-1', $partText->getCharset());
         $this->assertEquals('ISO-8859-1', $partHtml->getCharset());
     }
-    
+
     public function testGetNullCharsetForNonTextPlainOrHtmlPart()
     {
         $header = $this->getMockedParameterHeader('content-type', 'text/rtf');
@@ -504,7 +504,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $part = $this->newMimePart($pb);
         $this->assertNull($part->getCharset());
     }
-    
+
     public function testUsesTransferEncodingAndCharsetForStreamFilter()
     {
         $headerType = $this->getMockedParameterHeader('Content-Type', 'text/plain', 'wingding');
@@ -529,7 +529,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('klingon', $part->getContentTransferEncoding());
         $this->assertNotNull($part->getContentResourceHandle());
     }
-    
+
     public function testIsTextIsMultiPartForNonTextNonMultipart()
     {
         $header = $this->getMockedParameterHeader('Content-Type', 'stuff/blooh');
@@ -543,7 +543,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($part->isMultiPart());
         $this->assertFalse($part->isTextPart());
     }
-    
+
     public function testIsTextForTextPlain()
     {
         $header = $this->getMockedParameterHeader('Content-Type', 'text/plain');
@@ -557,7 +557,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($part->isMultiPart());
         $this->assertTrue($part->isTextPart());
     }
-    
+
     public function testIsTextForTextHtml()
     {
         $header = $this->getMockedParameterHeader('Content-Type', 'text/html');
@@ -571,7 +571,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($part->isMultiPart());
         $this->assertTrue($part->isTextPart());
     }
-    
+
     public function testIsTextForTextMimeTypeWithCharset()
     {
         $header = $this->getMockedParameterHeader('Content-Type', 'text/blah', 'utf-8');
@@ -585,7 +585,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($part->isMultiPart());
         $this->assertTrue($part->isTextPart());
     }
-    
+
     public function testIsTextForTextMimeTypeWithoutCharset()
     {
         $header = $this->getMockedParameterHeader('Content-Type', 'text/blah');
@@ -599,7 +599,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($part->isMultiPart());
         $this->assertFalse($part->isTextPart());
     }
-    
+
     public function testIsMultipartForMultipartRelated()
     {
         $header = $this->getMockedParameterHeader('Content-Type', 'multipart/related');
@@ -613,7 +613,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($part->isMultiPart());
         $this->assertFalse($part->isTextPart());
     }
-    
+
     public function testIsMultipartForMultipartAnything()
     {
         $header = $this->getMockedParameterHeader('Content-Type', 'multipart/anything');
@@ -627,7 +627,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($part->isMultiPart());
         $this->assertFalse($part->isTextPart());
     }
-    
+
     public function testGetAllPartsByMimeType()
     {
         $pf = $this->mockPartFilterFactory;
@@ -637,7 +637,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $filter->expects($this->exactly(5))
             ->method('filter')
             ->willReturnOnConsecutiveCalls(true, true, false, false, false);
-        
+
         $pf->expects($this->once())
             ->method('newFilterFromContentType')
             ->with('awww geez')
@@ -647,7 +647,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $parts = $part->getAllPartsByMimeType('awww geez');
         $this->assertCount(2, $parts);
     }
-    
+
     public function testGetPartByMimeType()
     {
         $pf = $this->mockPartFilterFactory;
@@ -660,7 +660,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
                 true, false, false, true, false,
                 true, false, false, true, false
             );
-        
+
         $pf->expects($this->exactly(2))
             ->method('newFilterFromContentType')
             ->with('awww geez')
@@ -670,7 +670,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $this->assertSame($part, $part->getPartByMimeType('awww geez'));
         $this->assertSame($part->getPart(3), $part->getPartByMimeType('awww geez', 1));
     }
-    
+
     public function testGetCountOfPartsByMimeType()
     {
         $pf = $this->mockPartFilterFactory;
@@ -680,7 +680,7 @@ class MimePartTest extends PHPUnit_Framework_TestCase
         $filter->expects($this->exactly(5))
             ->method('filter')
             ->willReturnOnConsecutiveCalls(true, true, false, false, true);
-        
+
         $pf->expects($this->once())
             ->method('newFilterFromContentType')
             ->with('awww geez, Rick')

--- a/tests/MailMimeParser/Message/Part/NonMimePartTest.php
+++ b/tests/MailMimeParser/Message/Part/NonMimePartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 
 /**
@@ -12,7 +12,7 @@ use GuzzleHttp\Psr7;
  * @covers ZBateson\MailMimeParser\Message\Part\NonMimePart
  * @author Zaahid Bateson
  */
-class NonMimePartTest extends PHPUnit_Framework_TestCase
+class NonMimePartTest extends TestCase
 {
     public function testInstance()
     {

--- a/tests/MailMimeParser/Message/Part/PartBuilderTest.php
+++ b/tests/MailMimeParser/Message/Part/PartBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 
 /**
@@ -12,7 +12,7 @@ use GuzzleHttp\Psr7;
  * @covers ZBateson\MailMimeParser\Message\Part\PartBuilder
  * @author Zaahid Bateson
  */
-class PartBuilderTest extends PHPUnit_Framework_TestCase
+class PartBuilderTest extends TestCase
 {
     private $mockMessagePartFactory;
 
@@ -30,7 +30,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
     }
-    
+
     public function testCanHaveHeaders()
     {
         $mockHeader = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
@@ -41,12 +41,12 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->method('getValueFor')
             ->with('boundary')
             ->willReturn('Castle Black');
-        
+
         $instance = new PartBuilder(
             $this->mockMessagePartFactory,
             $this->newMockHeaderContainer()
         );
-        
+
         $this->assertTrue($instance->canHaveHeaders());
 
         $hc = $this->newMockHeaderContainer();
@@ -63,7 +63,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->willReturn($mockHeader);
         $parent->addHeader('CONTENT-TYPE', 'kookoo-keekee');
         $parent->addChild($instance);
-        
+
         $parent->setEndBoundaryFound('--Castle Black--');
         $this->assertFalse($instance->canHaveHeaders());
     }
@@ -91,7 +91,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertSame($instance, $children[0]->getParent());
         $this->assertSame($instance, $children[1]->getParent());
     }
-    
+
     public function testAddAndGetRawHeaders()
     {
         $hc = $this->newMockHeaderContainer();
@@ -112,7 +112,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($hc, $instance->getHeaderContainer());
     }
-    
+
     public function testIsMime()
     {
         $hc = $this->newMockHeaderContainer();
@@ -135,7 +135,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($instance->isMime());
         $this->assertFalse($instance->isMime());
     }
-    
+
     public function testGetContentType()
     {
         $hc = $this->newMockHeaderContainer();
@@ -149,7 +149,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->willReturn(true);
         $this->assertTrue($instance->getContentType());
     }
-    
+
     public function testGetMimeBoundary()
     {
         $mockHeader = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
@@ -172,7 +172,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->willReturn($mockHeader);
         $this->assertEquals('Castle Black', $instance->getMimeBoundary());
     }
-    
+
     public function testIsMultiPart()
     {
         $mockHeader = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
@@ -196,7 +196,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($instance->isMultiPart());
         $this->assertFalse($instance->isMultiPart());
     }
-    
+
     public function testSetEndBoundaryFound()
     {
         $mockHeader = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
@@ -207,7 +207,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->method('getValueFor')
             ->with('boundary')
             ->willReturn('Castle Black');
-        
+
         $hc = $this->newMockHeaderContainer();
         $instance = new PartBuilder(
             $this->mockMessagePartFactory,
@@ -217,14 +217,14 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->method('get')
             ->with('Content-Type', 0)
             ->willReturn($mockHeader);
-        
+
         $this->assertFalse($instance->isParentBoundaryFound());
         $this->assertFalse($instance->setEndBoundaryFound('Somewhere... obvs not Castle Black'));
         $this->assertFalse($instance->setEndBoundaryFound('Castle Black'));
         $this->assertTrue($instance->setEndBoundaryFound('--Castle Black'));
         $this->assertFalse($instance->isParentBoundaryFound());
         $this->assertTrue($instance->setEndBoundaryFound('--Castle Black--'));
-        
+
         $child = new PartBuilder(
             $this->mockMessagePartFactory,
             $this->newMockHeaderContainer()
@@ -234,7 +234,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertCount(0, $instance->getChildren());
         $this->assertFalse($child->canHaveHeaders());
     }
-    
+
     public function testSetEndBoundaryFoundWithParent()
     {
         $mockParentHeader = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
@@ -245,7 +245,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->method('getValueFor')
             ->with('boundary')
             ->willReturn('King\'s Landing');
-        
+
         $mockHeader = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
             ->disableOriginalConstructor()
             ->setMethods(['getValueFor'])
@@ -275,7 +275,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             $hcp
         );
         $parent->addChild($instance);
-        
+
         $this->assertSame($parent, $instance->getParent());
         $this->assertFalse($instance->isParentBoundaryFound());
         $this->assertFalse($instance->setEndBoundaryFound('Somewhere... obvs not Castle Black'));
@@ -283,7 +283,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($instance->setEndBoundaryFound('--King\'s Landing'));
         $this->assertTrue($instance->isParentBoundaryFound());
     }
-    
+
     public function testSetEof()
     {
         $mockParentHeader = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
@@ -294,7 +294,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->method('getValueFor')
             ->with('boundary')
             ->willReturn('King\'s Landing');
-        
+
         $mockHeader = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
             ->disableOriginalConstructor()
             ->setMethods(['getValueFor'])
@@ -303,7 +303,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             ->method('getValueFor')
             ->with('boundary')
             ->willReturn(null);
-        
+
         $hc = $this->newMockHeaderContainer();
         $hc->expects($this->atLeastOnce())
             ->method('get')
@@ -324,7 +324,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
             $hcp
         );
         $parent->addChild($instance);
-        
+
         $this->assertSame($parent, $instance->getParent());
         $this->assertFalse($instance->isParentBoundaryFound());
         $this->assertFalse($instance->setEndBoundaryFound('Somewhere... obvs not Castle Black'));
@@ -335,7 +335,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($instance->isParentBoundaryFound());
         $this->assertTrue($parent->isParentBoundaryFound());
     }
-    
+
     public function testSetStreamPartPosAndGetFilename()
     {
         $instance = new PartBuilder(
@@ -347,7 +347,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(42, $instance->getStreamPartStartOffset());
         $this->assertEquals(42, $instance->getStreamPartLength());
     }
-    
+
     public function testSetStreamContentPosAndGetFilename()
     {
         $instance = new PartBuilder(
@@ -362,7 +362,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(42, $instance->getStreamContentStartOffset());
         $this->assertEquals(84 - 42, $instance->getStreamContentLength());
     }
-    
+
     public function testSetStreamContentPosAndGetFilenameWithParent()
     {
         $instance = new PartBuilder(
@@ -379,15 +379,15 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         );
         $parent->addChild($instance);
         $super->addChild($parent);
-        
+
         $super->setStreamPartStartPos(0);
         $super->setStreamContentStartPos(3);
         $super->setStreamPartAndContentEndPos(3);
-        
+
         $parent->setStreamPartStartPos(11);
         $parent->setStreamContentStartPos(13);
         $parent->setStreamPartAndContentEndPos(20);
-        
+
         $instance->setStreamPartStartPos(22);
         $instance->setStreamContentStartPos(42);
         $instance->setStreamPartAndContentEndPos(84);
@@ -407,7 +407,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $super->getStreamPartStartOffset());
         $this->assertEquals(84, $super->getStreamPartLength());
     }
-    
+
     public function testSetAndGetProperties()
     {
         $instance = new PartBuilder(
@@ -420,7 +420,7 @@ class PartBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertSame('King\'s Landing', $instance->getProperty('capital'));
         $this->assertNull($instance->getProperty('Joffrey\'s kindness'));
     }
-    
+
     public function testCreateMessagePart()
     {
         $stream = Psr7\stream_for('thingsnstuff');

--- a/tests/MailMimeParser/Message/Part/PartStreamFilterManagerTest.php
+++ b/tests/MailMimeParser/Message/Part/PartStreamFilterManagerTest.php
@@ -1,23 +1,23 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 use ZBateson\StreamDecorators\NonClosingStream;
 
 /**
  * PartStreamFilterManagerTest
- * 
+ *
  * @group PartStreamFilterManager
  * @group MessagePart
  * @covers ZBateson\MailMimeParser\Message\Part\PartStreamFilterManager
  * @author Zaahid Bateson
  */
-class PartStreamFilterManagerTest extends PHPUnit_Framework_TestCase
+class PartStreamFilterManagerTest extends TestCase
 {
     private $partStreamFilterManager = null;
     private $mockStreamFactory = null;
-    
+
     protected function setUp()
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
@@ -25,7 +25,7 @@ class PartStreamFilterManagerTest extends PHPUnit_Framework_TestCase
         $this->partStreamFilterManager = new PartStreamFilterManager($mocksdf);
         $this->mockStreamFactory = $mocksdf;
     }
-    
+
     public function testAttachQuotedPrintableDecoder()
     {
         $stream = Psr7\stream_for('test');
@@ -40,7 +40,7 @@ class PartStreamFilterManagerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\GuzzleHttp\Psr7\CachingStream', $managerStream);
         $this->assertEquals('test', $managerStream->getContents());
     }
-    
+
     public function testAttachBase64Decoder()
     {
         $stream = Psr7\stream_for('test');
@@ -53,7 +53,7 @@ class PartStreamFilterManagerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\GuzzleHttp\Psr7\CachingStream', $managerStream);
         $this->assertEquals('test', $managerStream->getContents());
     }
-    
+
     public function testAttachUUEncodeDecoder()
     {
         $stream = Psr7\stream_for('test');
@@ -66,7 +66,7 @@ class PartStreamFilterManagerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\GuzzleHttp\Psr7\CachingStream', $managerStream);
         $this->assertEquals('test', $managerStream->getContents());
     }
-    
+
     public function testAttachCharsetConversionDecoder()
     {
         $stream = Psr7\stream_for('test');
@@ -79,7 +79,7 @@ class PartStreamFilterManagerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\GuzzleHttp\Psr7\CachingStream', $managerStream);
         $this->assertEquals('test', $managerStream->getContents());
     }
-    
+
     public function testReAttachTransferEncodingDecoder()
     {
         $stream = Psr7\stream_for('test');
@@ -88,7 +88,7 @@ class PartStreamFilterManagerTest extends PHPUnit_Framework_TestCase
             ->with($stream)
             ->willReturn($stream);
         $stream->rewind();
-        
+
         $stream2 = Psr7\stream_for('test2');
         $stream3 = Psr7\stream_for('test3');
         $this->mockStreamFactory->expects($this->exactly(2))
@@ -107,7 +107,7 @@ class PartStreamFilterManagerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('test3', $manager->getContentStream('x-uuencode', null, null)->getContents());
     }
-    
+
     public function testReAttachCharsetConversionDecoder()
     {
         $stream = Psr7\stream_for('test');
@@ -130,7 +130,7 @@ class PartStreamFilterManagerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('test', $manager->getContentStream(null, 'ISO-8859-1', 'WINDOWS-1252')->getContents());
         $this->assertEquals('test', $manager->getContentStream(null, 'WINDOWS-1252', 'UTF-8')->getContents());
     }
-    
+
     public function testAttachCharsetConversionAndTransferEncodingDecoder()
     {
         $stream = Psr7\stream_for('test');

--- a/tests/MailMimeParser/Message/Part/UUEncodedPartTest.php
+++ b/tests/MailMimeParser/Message/Part/UUEncodedPartTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Message\Part;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 
 /**
@@ -12,7 +12,7 @@ use GuzzleHttp\Psr7;
  * @covers ZBateson\MailMimeParser\Message\Part\UUEncodedPart
  * @author Zaahid Bateson
  */
-class UUEncodedPartTest extends PHPUnit_Framework_TestCase
+class UUEncodedPartTest extends TestCase
 {
     public function testInstance()
     {
@@ -22,7 +22,7 @@ class UUEncodedPartTest extends PHPUnit_Framework_TestCase
         $sf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $pb = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartBuilder')
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/MailMimeParser/Message/PartFilterFactoryTest.php
+++ b/tests/MailMimeParser/Message/PartFilterFactoryTest.php
@@ -1,26 +1,26 @@
 <?php
 namespace ZBateson\MailMimeParser\Message;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PartFilterFactoryTest
- * 
+ *
  * @group PartFilterFactory
  * @group Message
  * @covers ZBateson\MailMimeParser\Message\PartFilterFactory
  * @covers ZBateson\MailMimeParser\Message\PartFilter
  * @author Zaahid Bateson
  */
-class PartFilterFactoryTest extends PHPUnit_Framework_TestCase
+class PartFilterFactoryTest extends TestCase
 {
     protected $partFilterFactory;
-    
+
     protected function setUp()
     {
         $this->partFilterFactory = new PartFilterFactory();
     }
-    
+
     public function testNewFilterFromContentType()
     {
         $pf = $this->partFilterFactory->newFilterFromContentType('text/html');
@@ -34,7 +34,7 @@ class PartFilterFactoryTest extends PHPUnit_Framework_TestCase
             $pf->headers
         );
     }
-    
+
     public function testNewFilterFromInlineContentType()
     {
         $pf = $this->partFilterFactory->newFilterFromInlineContentType('text/html');
@@ -51,7 +51,7 @@ class PartFilterFactoryTest extends PHPUnit_Framework_TestCase
             $pf->headers
         );
     }
-    
+
     public function testNewFilterFromDisposition()
     {
         $pf = $this->partFilterFactory->newFilterFromDisposition('inline', PartFilter::FILTER_EXCLUDE);
@@ -67,7 +67,7 @@ class PartFilterFactoryTest extends PHPUnit_Framework_TestCase
             $pf->headers
         );
     }
-    
+
     public function testNewFilterFromArray()
     {
         $headers = [

--- a/tests/MailMimeParser/Message/PartFilterTest.php
+++ b/tests/MailMimeParser/Message/PartFilterTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser\Message;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PartFilterTest
@@ -11,10 +11,10 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Message\PartFilter
  * @author Zaahid Bateson
  */
-class PartFilterTest extends PHPUnit_Framework_TestCase
+class PartFilterTest extends TestCase
 {
     private $parts = [];
-    
+
     protected function getMockedPartWithContentType($mimeType, $disposition = null, $isText = false)
     {
         $part = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\MimePart')
@@ -37,7 +37,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $part->method('isTextPart')->willReturn($isText);
         return $part;
     }
-    
+
     protected function getMockedSignedPart()
     {
         $parent = $this->getMockedPartWithContentType('multipart/signed');
@@ -46,7 +46,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $part->method('getParent')->willReturn($parent);
         return $part;
     }
-    
+
     public function setUp()
     {
         parent::setUp();
@@ -63,10 +63,10 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
             $signedPart
         ];
     }
-    
+
     public function testFromContentType()
     {
-        
+
         $filter = PartFilter::fromContentType('text/html');
         $this->assertNotNull($filter);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Message\PartFilter', $filter);
@@ -82,7 +82,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertSame($this->parts[2], $filtered[1]);
         $this->assertSame($this->parts[4], $filtered[2]);
     }
-    
+
     public function testFromInlineContentType()
     {
         $filter = PartFilter::fromInlineContentType('text/html');
@@ -102,10 +102,10 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertSame($this->parts[0], $filtered[0]);
         $this->assertSame($this->parts[2], $filtered[1]);
     }
-    
+
     public function testFromNonExistentContentType()
     {
-        
+
         $filter = PartFilter::fromContentType('doesnot/exist');
         $this->assertNotNull($filter);
         $this->assertInstanceOf('\ZBateson\MailMimeParser\Message\PartFilter', $filter);
@@ -118,7 +118,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $filtered = array_values(array_filter($this->parts, [ $filter, 'filter' ]));
         $this->assertEmpty($filtered);
     }
-    
+
     public function testFromDispositionAttachment()
     {
         $filter = PartFilter::fromDisposition('attachment');
@@ -127,13 +127,13 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(PartFilter::FILTER_OFF, $filter->multipart);
         $this->assertEquals(PartFilter::FILTER_OFF, $filter->textpart);
         $this->assertEquals(PartFilter::FILTER_EXCLUDE, $filter->signedpart);
-        
+
         $filtered = array_values(array_filter($this->parts, [ $filter, 'filter' ]));
         $this->assertCount(2, $filtered);
         $this->assertSame($this->parts[3], $filtered[0]);
         $this->assertSame($this->parts[4], $filtered[1]);
     }
-    
+
     public function testFromDispositionInline()
     {
         $filter = PartFilter::fromDisposition('inline');
@@ -147,7 +147,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertSame($this->parts[1], $filtered[0]);
         $this->assertSame($this->parts[2], $filtered[1]);
     }
-    
+
     public function testFromDispositionInlineExcludeMultiPart()
     {
         $filter = PartFilter::fromDisposition('inline', PartFilter::FILTER_EXCLUDE);
@@ -160,7 +160,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $filtered);
         $this->assertSame($this->parts[2], $filtered[0]);
     }
-    
+
     public function testFromDispositionInlineIncludeMultiPart()
     {
         $filter = PartFilter::fromDisposition('inline', PartFilter::FILTER_INCLUDE);
@@ -173,7 +173,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $filtered);
         $this->assertSame($this->parts[1], $filtered[0]);
     }
-    
+
     public function testForNonExistentDisposition()
     {
         $filter = PartFilter::fromDisposition('unreal');
@@ -185,7 +185,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $filtered = array_values(array_filter($this->parts, [ $filter, 'filter' ]));
         $this->assertEmpty($filtered);
     }
-    
+
     public function testMultiPartFilterInclude()
     {
         $filter = new PartFilter([
@@ -196,14 +196,14 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(PartFilter::FILTER_INCLUDE, $filter->multipart);
         $this->assertEquals(PartFilter::FILTER_OFF, $filter->textpart);
         $this->assertEquals(PartFilter::FILTER_EXCLUDE, $filter->signedpart);
-        
+
         $filtered = array_values(array_filter($this->parts, [ $filter, 'filter' ]));
         $this->assertCount(3, $filtered);
         $this->assertSame($this->parts[1], $filtered[0]);
         $this->assertSame($this->parts[5], $filtered[1]);
         $this->assertSame($this->parts[6], $filtered[2]);
     }
-    
+
     public function testMultiPartFilterExcludeWithHeaderExcludeFilter()
     {
         $filter = new PartFilter([
@@ -223,7 +223,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $filtered);
         $this->assertSame($this->parts[3], $filtered[0]);
     }
-    
+
     public function testMultiPartFilterIncludeWithHeaderExcludeFilter()
     {
         $filter = new PartFilter([
@@ -244,7 +244,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertSame($this->parts[5], $filtered[0]);
         $this->assertSame($this->parts[6], $filtered[1]);
     }
-    
+
     public function testTextPartFilterInclude()
     {
         $filter = new PartFilter([
@@ -255,7 +255,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(PartFilter::FILTER_OFF, $filter->multipart);
         $this->assertEquals(PartFilter::FILTER_INCLUDE, $filter->textpart);
         $this->assertEquals(PartFilter::FILTER_EXCLUDE, $filter->signedpart);
-        
+
         $filtered = array_values(array_filter($this->parts, [ $filter, 'filter' ]));
         $this->assertCount(4, $filtered);
         $this->assertSame($this->parts[0], $filtered[0]);
@@ -263,7 +263,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertSame($this->parts[3], $filtered[2]);
         $this->assertSame($this->parts[4], $filtered[3]);
     }
-    
+
     public function testTextPartFilterExcludeWithHeaderExcludeFilter()
     {
         $filter = new PartFilter([
@@ -284,7 +284,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertSame($this->parts[1], $filtered[0]);
         $this->assertSame($this->parts[6], $filtered[1]);
     }
-    
+
     public function testTextPartFilterIncludeWithHeaderExcludeFilter()
     {
         $filter = new PartFilter([
@@ -304,7 +304,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $filtered);
         $this->assertSame($this->parts[3], $filtered[0]);
     }
-    
+
     public function testSignedPartFilterInclude()
     {
         $filter = new PartFilter([
@@ -315,12 +315,12 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(PartFilter::FILTER_OFF, $filter->multipart);
         $this->assertEquals(PartFilter::FILTER_OFF, $filter->textpart);
         $this->assertEquals(PartFilter::FILTER_INCLUDE, $filter->signedpart);
-        
+
         $filtered = array_values(array_filter($this->parts, [ $filter, 'filter' ]));
         $this->assertCount(1, $filtered);
         $this->assertSame($this->parts[7], $filtered[0]);
     }
-    
+
     public function testSignedPartFilterOffWithDispositionExclude()
     {
         $filter = new PartFilter([
@@ -336,7 +336,7 @@ class PartFilterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(PartFilter::FILTER_OFF, $filter->multipart);
         $this->assertEquals(PartFilter::FILTER_OFF, $filter->textpart);
         $this->assertEquals(PartFilter::FILTER_OFF, $filter->signedpart);
-        
+
         $filtered = array_values(array_filter($this->parts, [ $filter, 'filter' ]));
         $this->assertCount(6, $filtered);
         $this->assertSame($this->parts[0], $filtered[0]);

--- a/tests/MailMimeParser/MessageTest.php
+++ b/tests/MailMimeParser/MessageTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
 use org\bovigo\vfs\vfsStream;
 
@@ -13,7 +13,7 @@ use org\bovigo\vfs\vfsStream;
  * @covers ZBateson\MailMimeParser\Message
  * @author Zaahid Bateson
  */
-class MessageTest extends PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     private $mockPartStreamFilterManager;
     private $mockHeaderFactory;
@@ -41,7 +41,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
     }
-    
+
     protected function getMockedParameterHeader($name, $value, $parameterValue = null)
     {
         $header = $this->getMockBuilder('ZBateson\MailMimeParser\Header\ParameterHeader')
@@ -54,7 +54,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
         $header->method('hasParameter')->willReturn(true);
         return $header;
     }
-    
+
     protected function getMockedPartBuilder()
     {
         $hc = $this->getMockBuilder('ZBateson\MailMimeParser\Header\HeaderContainer')
@@ -67,7 +67,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             ->willReturn($hc);
         return $pb;
     }
-    
+
     protected function getMockedPartBuilderWithChildren()
     {
         $pb = $this->getMockedPartBuilder();
@@ -76,17 +76,17 @@ class MessageTest extends PHPUnit_Framework_TestCase
             $this->getMockedPartBuilder(),
             $this->getMockedPartBuilder()
         ];
-        
+
         $nestedMimePart = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\MimePart')
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $nested = $this->getMockedPartBuilder();
         $nested->method('createMessagePart')
             ->willReturn($nestedMimePart);
         $children[0]->method('getChildren')
             ->willReturn([$nested]);
-        
+
         foreach ($children as $key => $child) {
             // need to 'setMethods' because getAllNonFilteredParts is protected
             $childMimePart = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\MimePart')
@@ -105,7 +105,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             $childMimePart->
                 method('getMessageObjectId')
                 ->willReturn('child' . $key);
-            
+
             if ($key === 0) {
                 $childMimePart->expects($this->any())
                     ->method('getAllNonFilteredParts')
@@ -115,7 +115,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
                     ->method('getAllNonFilteredParts')
                     ->willReturn([$childMimePart]);
             }
-            
+
             $child->method('createMessagePart')
                 ->willReturn($childMimePart);
         }
@@ -145,7 +145,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($message);
         $this->assertInstanceOf('ZBateson\MailMimeParser\Message', $message);
     }
-    
+
     public function testGetTextPartAndTextPartCount()
     {
         $filterMock = $this->getMockBuilder('ZBateson\MailMimeParser\Message\PartFilter')
@@ -183,7 +183,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             ->method('getContentResourceHandle')
             ->with('charset')
             ->willReturn('tilkomore');
-        
+
         $this->assertEquals(2, $message->getTextPartCount());
         $this->assertEquals($parts[1], $message->getTextPart());
         $this->assertEquals($parts[3], $message->getTextPart(1));
@@ -195,7 +195,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('shabadabada...', $message->getTextContent(0, 'charset'));
         $this->assertEquals('tilkomore', $message->getTextResourceHandle(1, 'charset'));
     }
-    
+
     public function testGetHtmlPartAndHtmlPartCount()
     {
         $filterMock = $this->getMockBuilder('ZBateson\MailMimeParser\Message\PartFilter')
@@ -207,7 +207,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             $this->getMockedPartBuilderWithChildren()
         );
         $parts = $message->getAllParts();
-        
+
         $filterMock
             ->method('filter')
             ->willReturnMap(
@@ -234,7 +234,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             ->method('getContentResourceHandle')
             ->with('charset')
             ->willReturn('tilkomore');
-        
+
         $this->assertEquals(2, $message->getHtmlPartCount());
         $this->assertEquals($parts[1], $message->getHtmlPart());
         $this->assertEquals($parts[3], $message->getHtmlPart(1));
@@ -246,7 +246,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('shabadabada...', $message->getHtmlContent(0, 'charset'));
         $this->assertEquals('tilkomore', $message->getHtmlResourceHandle(1, 'charset'));
     }
-    
+
     public function testGetAndRemoveAttachmentParts()
     {
         $filterMock = $this->getMockBuilder('ZBateson\MailMimeParser\Message\PartFilter')
@@ -305,7 +305,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $message->getAttachmentCount());
         $this->assertEquals(null, $message->getAttachmentPart(0));
     }
-    
+
     public function testIsNotMime()
     {
         $message = $this->newMessage(
@@ -313,11 +313,11 @@ class MessageTest extends PHPUnit_Framework_TestCase
         );
         $this->assertFalse($message->isMime());
     }
-    
+
     public function testIsMimeWithContentType()
     {
         $header = $this->getMockedParameterHeader('Content-Type', 'text/html', 'utf-8');
-        
+
         $pb = $this->getMockedPartBuilder();
         $pb->method('getContentType')
             ->willReturn($header);
@@ -330,14 +330,14 @@ class MessageTest extends PHPUnit_Framework_TestCase
         );
         $this->assertTrue($message->isMime());
     }
-    
+
     public function testIsMimeWithMimeVersion()
     {
         $hf = $this->mockHeaderFactory;
         $header = $this->getMockedParameterHeader('Mime-Version', '4.3');
         $hf->method('newInstance')
             ->willReturn($header);
-        
+
         $pb = $this->getMockedPartBuilder();
         $hc = $pb->getHeaderContainer();
         $hc->method('get')
@@ -413,7 +413,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
                 [ $message, $this->isInstanceOf('Psr\Http\Message\StreamInterface'), 'mimetype2', 'inline', 'blueball.png' ]
             )
             ->willReturn($part);
-        
+
         $testFile = dirname(__DIR__) . '/' . TEST_DATA_DIR . '/emails/files/blueball.png';
         $message->addAttachmentPart('content', 'mimetype');
         $message->addAttachmentPartFromFile($testFile, 'mimetype2', null, 'inline');

--- a/tests/MailMimeParser/SimpleDiTest.php
+++ b/tests/MailMimeParser/SimpleDiTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace ZBateson\MailMimeParser;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of SimpleDiTest
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\SimpleDi
  * @author Zaahid Bateson
  */
-class SimpleDiTest extends PHPUnit_Framework_TestCase
+class SimpleDiTest extends TestCase
 {
     public function testSingleton()
     {
@@ -20,21 +20,21 @@ class SimpleDiTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZBateson\MailMimeParser\SimpleDi', $di);
         $this->assertSame($di, SimpleDi::singleton());
     }
-    
+
     public function testNewMessageParser()
     {
         $di = SimpleDi::singleton();
         $mp = $di->newMessageParser();
         $this->assertNotNull($mp);
     }
-    
+
     public function testGetCharsetConverter()
     {
         $di = SimpleDi::singleton();
         $m = $di->getCharsetConverter('ISO-8859-1', 'UTF-8');
         $this->assertNotNull($m);
     }
-    
+
     public function testGetHeaderFactory()
     {
         $di = SimpleDi::singleton();
@@ -42,7 +42,7 @@ class SimpleDiTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($singleton);
         $this->assertSame($singleton, $di->getHeaderFactory());
     }
-    
+
     public function testGetHeaderPartFactory()
     {
         $di = SimpleDi::singleton();
@@ -50,7 +50,7 @@ class SimpleDiTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($singleton);
         $this->assertSame($singleton, $di->getHeaderPartFactory());
     }
-    
+
     public function testGetMimeLiteralPartFactory()
     {
         $di = SimpleDi::singleton();
@@ -58,7 +58,7 @@ class SimpleDiTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($singleton);
         $this->assertSame($singleton, $di->getMimeLiteralPartFactory());
     }
-    
+
     public function testGetConsumerService()
     {
         $di = SimpleDi::singleton();

--- a/tests/MailMimeParser/Stream/HeaderStreamTest.php
+++ b/tests/MailMimeParser/Stream/HeaderStreamTest.php
@@ -2,7 +2,7 @@
 namespace ZBateson\MailMimeParser\Stream;
 
 use ArrayIterator;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * HeaderStreamTest
@@ -12,7 +12,7 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Stream\HeaderStream
  * @author Zaahid Bateson
  */
-class HeaderStreamTest extends PHPUnit_Framework_TestCase
+class HeaderStreamTest extends TestCase
 {
     private function newMockMimePart()
     {

--- a/tests/MailMimeParser/Stream/MessagePartStreamTest.php
+++ b/tests/MailMimeParser/Stream/MessagePartStreamTest.php
@@ -3,7 +3,7 @@ namespace ZBateson\MailMimeParser\Stream;
 
 use GuzzleHttp\Psr7;
 use ZBateson\StreamDecorators\NonClosingStream;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * MessagePartStreamTest
@@ -13,7 +13,7 @@ use PHPUnit_Framework_TestCase;
  * @covers ZBateson\MailMimeParser\Stream\MessagePartStream
  * @author Zaahid Bateson
  */
-class MessagePartStreamTest extends PHPUnit_Framework_TestCase
+class MessagePartStreamTest extends TestCase
 {
     private $mockStreamFactory;
 

--- a/tests/MailMimeParser/Stream/StreamFactoryTest.php
+++ b/tests/MailMimeParser/Stream/StreamFactoryTest.php
@@ -2,17 +2,17 @@
 namespace ZBateson\MailMimeParser\Stream;
 
 use GuzzleHttp\Psr7;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * StreamFactoryTest
- * 
+ *
  * @group StreamFactory
  * @group Stream
  * @covers ZBateson\MailMimeParser\Stream\StreamFactory
  * @author Zaahid Bateson
  */
-class StreamFactoryTest extends PHPUnit_Framework_TestCase
+class StreamFactoryTest extends TestCase
 {
     public function testNewInstance()
     {
@@ -34,7 +34,7 @@ class StreamFactoryTest extends PHPUnit_Framework_TestCase
             ->willReturn(4);
 
         $factory = new StreamFactory();
-        
+
         $this->assertInstanceOf('ZBateson\StreamDecorators\SeekingLimitStream', $factory->getLimitedPartStream(Psr7\stream_for('test'), $partBuilder));
         $this->assertInstanceOf('ZBateson\StreamDecorators\SeekingLimitStream', $factory->getLimitedContentStream(Psr7\stream_for('test'), $partBuilder));
         $this->assertNull($factory->getLimitedContentStream(Psr7\stream_for('test'), $partBuilder));


### PR DESCRIPTION
# Changed log
- Using the class-based PHPUnit namespace to be compatible with the latest PHPUnit version.
- The `getMock` API in PHPUnit is deprecated since PHPUnit `5.7+` version and it's the big work to do this. And the proper way is keep the PHPUnit version requiring `4.8` in `composer.json`.