### PR TITLE
Fix @param declaration in PhpDoc (string instead of type)

### DIFF
--- a/src/Header/Consumer/QuotedStringConsumer.php
+++ b/src/Header/Consumer/QuotedStringConsumer.php
@@ -50,7 +50,7 @@ class QuotedStringConsumer extends GenericConsumer
     /**
      * Returns true if the token is a double quote.
      * 
-     * @param type $token
+     * @param string $token
      * @return boolean
      */
     protected function isEndToken($token)

--- a/src/Message/Part/ParentHeaderPart.php
+++ b/src/Message/Part/ParentHeaderPart.php
@@ -67,7 +67,7 @@ abstract class ParentHeaderPart extends ParentPart
 
     /**
      * 
-     * @param type $name
+     * @param string $name
      */
     public function getAllHeadersByName($name)
     {


### PR DESCRIPTION
I think this should say "@param string ..." in these two places. 